### PR TITLE
feat: add wanderlog_rename_day tool

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -65,6 +65,11 @@ import {
   updateTripDatesDescription,
   updateTripDatesInputSchema,
 } from "./tools/update-trip-dates.js";
+import {
+  renameDay,
+  renameDayDescription,
+  renameDayInputSchema,
+} from "./tools/rename-day.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -253,6 +258,17 @@ export function buildServer(ctx: AppContext): McpServer {
     },
     requireAuth(ctx, async (args) =>
       updateTripDates(ctx, args as Parameters<typeof updateTripDates>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_rename_day",
+    {
+      title: "Rename a day heading in a Wanderlog trip",
+      description: renameDayDescription,
+      inputSchema: renameDayInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      renameDay(ctx, args as Parameters<typeof renameDay>[1])),
   );
 
   return server;

--- a/src/tools/rename-day.ts
+++ b/src/tools/rename-day.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogValidationError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { resolveDay } from "../resolvers/day.js";
+import { findDaySectionByDate, submitOp } from "./shared.js";
+
+export const renameDayInputSchema = {
+  trip_key: z.string().min(1).describe("The trip containing the day to rename."),
+  day: z
+    .string()
+    .min(1)
+    .describe(
+      'Which day to rename. Accepts "day 3", "May 4", or "2026-05-04".',
+    ),
+  heading: z
+    .string()
+    .describe(
+      'New heading for the day. Use "" (empty string) to clear the heading back to the auto-generated default.',
+    ),
+};
+
+export const renameDayDescription = `
+Renames the heading/subheading of a specific day in a Wanderlog trip.
+
+Day headings appear in the itinerary as the title for each day section (e.g. "Barcelona",
+"Ronda + Malaga"). Use this tool to replace them with more descriptive titles.
+
+Pass an empty string for "heading" to reset the day back to Wanderlog's auto-generated heading.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  day: string;
+  heading: string;
+};
+
+export async function renameDay(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    const daySection = resolveDay(trip, args.day);
+    const found = findDaySectionByDate(trip, daySection.date!);
+    if (!found) {
+      throw new WanderlogValidationError(`Day ${args.day} not found in trip`);
+    }
+
+    const oldHeading = found.section.heading;
+    const newHeading = args.heading;
+
+    if (oldHeading === newHeading) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Day ${daySection.date} heading is already "${newHeading}" — no change made.`,
+          },
+        ],
+      };
+    }
+
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", found.index, "heading"],
+        od: oldHeading,
+        oi: newHeading,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const oldLabel = oldHeading || "(auto-generated)";
+    const newLabel = newHeading || "(auto-generated)";
+    const text = `Renamed day ${daySection.date} in "${trip.title}": "${oldLabel}" → "${newLabel}"`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}


### PR DESCRIPTION
## What

Adds a new MCP tool `wanderlog_rename_day` that renames day section headings in a Wanderlog trip.

## Why

Day headings are auto-generated as generic city names (e.g. "Barcelona", "Lleida"). There's currently no way to set descriptive headings via MCP — you have to manually click each day in the Wanderlog UI. This tool fills that gap.

## How

Single JSON0 `od`/`oi` string-replace op on the section's `heading` field. Reuses existing `resolveDay()`, `findDaySectionByDate()`, and `submitOp()` helpers — zero changes to existing logic.

### Input schema

| Param | Type | Description |
|---|---|---|
| `trip_key` | string | The trip to modify |
| `day` | string | Natural-language day ref: `"day 3"`, `"May 4"`, `"2026-05-04"` |
| `heading` | string | New heading text. Empty string resets to auto-generated default |

### Example

```
wanderlog_rename_day(
  trip_key: "abc123",
  day: "May 6",
  heading: "Aigüestortes — full-day guided hike"
)
```

## Files changed

- `src/tools/rename-day.ts` — **new** (88 lines, follows existing tool conventions)
- `src/server.ts` — import + `registerTool()` call (16 lines added)

## Testing

Tested against a live trip (23 days). All 20 heading renames succeeded on first attempt:

```
Apr 25: ✓ "Seville" → "Arrival — Seville + Feria de Abril"
May  6: ✓ "Lleida"  → "Aigüestortes — full-day guided hike"
May  8: ✓ ""        → "Via Ferrata → Parador de Cardona"
...
Done: 20 succeeded, 0 failed
```