### PR TITLE
feat: add wanderlog_remove_note and wanderlog_edit_note tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ and a ryokan in Shinjuku."
 ```
 "Remove the Colosseum from day 2 of my Rome trip."
 ```
+```
+"Update the day-1 note on my Tokyo trip to mention the Suica card refund desk at the airport."
+```
 
 ## Tools
 
@@ -77,6 +80,8 @@ and a ryokan in Shinjuku."
 | `wanderlog_add_expense` | Log a budget expense (amount, category, currency) linked to a place |
 | `wanderlog_annotate_place` | Update an existing place with a note, start/end time, or both |
 | `wanderlog_remove_place` | Remove a place by natural-language reference |
+| `wanderlog_remove_note` | Remove a note by natural-language reference |
+| `wanderlog_edit_note` | Replace a note's text in place — preserves block position and id |
 | `wanderlog_update_trip_dates` | Change a trip's date range |
 | `wanderlog_rename_day` | Rename a day's heading (e.g. `"Barcelona"` → `"Arrival — Feria de Abril"`) |
 

--- a/src/formatters/trip-summary.ts
+++ b/src/formatters/trip-summary.ts
@@ -4,13 +4,13 @@ import type {
   FlightBlock,
   NoteBlock,
   PlaceBlock,
-  QuillDelta,
   Section,
   TrainBlock,
   TripPlan,
   TripPlanSummary,
   UnknownBlock,
 } from "../types.js";
+import { quillToPlain } from "../types.js";
 
 export type ResponseFormat = "concise" | "detailed";
 
@@ -301,14 +301,6 @@ function formatTime(iso: string): string {
   // ISO times like "2025-11-13T09:00:00Z" or "09:00" — keep it tolerant.
   const match = /(\d{2}:\d{2})/.exec(iso);
   return match ? match[1]! : iso;
-}
-
-/** Extract plain text from a Quill Delta `{ops: [{insert: "..."}]}`. */
-function quillToPlain(delta: QuillDelta | undefined): string {
-  if (!delta?.ops) return "";
-  return delta.ops
-    .map((op) => (typeof op.insert === "string" ? op.insert : ""))
-    .join("");
 }
 
 function formatDayLabel(section: Section): string {

--- a/src/resolvers/note-ref.ts
+++ b/src/resolvers/note-ref.ts
@@ -1,0 +1,150 @@
+import type { NoteBlock, Section, TripPlan } from "../types.js";
+import { isNoteBlock, quillToPlain } from "../types.js";
+import { parseOrdinal } from "./place-ref.js";
+import { resolveDay } from "./day.js";
+
+export type NoteRefMatch = {
+  sectionIndex: number;
+  blockIndex: number;
+  section: Section;
+  block: NoteBlock;
+};
+
+export type NoteRefResult =
+  | { kind: "unique"; match: NoteRefMatch }
+  | { kind: "ambiguous"; candidates: NoteRefMatch[] }
+  | { kind: "none" };
+
+const MAX_AMBIGUOUS_CANDIDATES = 10;
+
+const ROLE_KEYWORDS = new Set(["note", "the note", "my note", "a note"]);
+
+/**
+ * Resolves a free-form natural-language reference to a note block in a trip.
+ *
+ * Strategy order (short-circuits on the first stage that yields candidates):
+ *   0. Ordinal prefix ("1st X", "last X", "second X") — strips the ordinal,
+ *      resolves the rest via the normal flow, then picks the N-th candidate.
+ *      Combines with compound refs: "2nd milford on day 3" is valid.
+ *   1. Compound "<thing> on <day>" — left side resolved by stages 2-3, then
+ *      filtered to candidates whose parent section matches the day.
+ *   2. Role keyword ("the note", "note") — every note in the trip (or the
+ *      filtered day). Usually ambiguous unless there's exactly one.
+ *   3. Substring (case-insensitive) match against the note's plain text.
+ *
+ * Matches the plain text extracted from `text.ops[].insert` — formatting and
+ * links are stripped. Diacritics are not normalized.
+ */
+export function resolveNoteRef(trip: TripPlan, ref: string): NoteRefResult {
+  const normalized = normalize(ref);
+  if (!normalized) {
+    return { kind: "none" };
+  }
+
+  const sections = trip.itinerary.sections;
+  if (sections.length === 0) {
+    return { kind: "none" };
+  }
+
+  const ordinal = parseOrdinal(normalized);
+  const body = ordinal ? ordinal.rest : normalized;
+
+  const compound = splitCompound(body);
+  const candidates = compound
+    ? filterByDay(trip, findByLeftSide(trip, compound.left), compound.right)
+    : findByLeftSide(trip, body);
+
+  if (ordinal) {
+    if (candidates.length === 0) return { kind: "none" };
+    const index =
+      ordinal.position === "last" ? candidates.length - 1 : ordinal.position - 1;
+    if (index < 0 || index >= candidates.length) {
+      return { kind: "none" };
+    }
+    return { kind: "unique", match: candidates[index]! };
+  }
+
+  return finalize(candidates);
+}
+
+function findByLeftSide(trip: TripPlan, ref: string): NoteRefMatch[] {
+  if (ROLE_KEYWORDS.has(ref)) {
+    return allNotes(trip);
+  }
+  return matchNoteText(trip, ref);
+}
+
+function allNotes(trip: TripPlan): NoteRefMatch[] {
+  const matches: NoteRefMatch[] = [];
+  const sections = trip.itinerary.sections;
+  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    const section = sections[sectionIndex]!;
+    for (let blockIndex = 0; blockIndex < section.blocks.length; blockIndex++) {
+      const block = section.blocks[blockIndex]!;
+      if (isNoteBlock(block)) {
+        matches.push({ sectionIndex, blockIndex, section, block });
+      }
+    }
+  }
+  return matches;
+}
+
+function matchNoteText(trip: TripPlan, ref: string): NoteRefMatch[] {
+  const matches: NoteRefMatch[] = [];
+  const sections = trip.itinerary.sections;
+  for (let sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    const section = sections[sectionIndex]!;
+    for (let blockIndex = 0; blockIndex < section.blocks.length; blockIndex++) {
+      const block = section.blocks[blockIndex]!;
+      if (!isNoteBlock(block)) continue;
+      const text = normalize(quillToPlain(block.text));
+      if (text && text.includes(ref)) {
+        matches.push({ sectionIndex, blockIndex, section, block });
+      }
+    }
+  }
+  return matches;
+}
+
+function splitCompound(ref: string): { left: string; right: string } | null {
+  const idx = ref.indexOf(" on ");
+  if (idx < 0) return null;
+  const left = ref.slice(0, idx).trim();
+  const right = ref.slice(idx + 4).trim();
+  if (!left || !right) return null;
+  return { left, right };
+}
+
+function filterByDay(
+  trip: TripPlan,
+  candidates: NoteRefMatch[],
+  context: string,
+): NoteRefMatch[] {
+  if (candidates.length === 0) return candidates;
+  const daySection = tryResolveDay(trip, context);
+  if (daySection) {
+    return candidates.filter((c) => c.section === daySection);
+  }
+  return [];
+}
+
+function tryResolveDay(trip: TripPlan, ref: string): Section | null {
+  try {
+    return resolveDay(trip, ref);
+  } catch {
+    return null;
+  }
+}
+
+function finalize(candidates: NoteRefMatch[]): NoteRefResult {
+  if (candidates.length === 0) return { kind: "none" };
+  if (candidates.length === 1) return { kind: "unique", match: candidates[0]! };
+  return {
+    kind: "ambiguous",
+    candidates: candidates.slice(0, MAX_AMBIGUOUS_CANDIDATES),
+  };
+}
+
+function normalize(s: string): string {
+  return s.replace(/\s+/g, " ").trim().toLowerCase();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,16 @@ import {
   listTripsInputSchema,
 } from "./tools/list-trips.js";
 import {
+  removeNote,
+  removeNoteDescription,
+  removeNoteInputSchema,
+} from "./tools/remove-note.js";
+import {
+  editNote,
+  editNoteDescription,
+  editNoteInputSchema,
+} from "./tools/edit-note.js";
+import {
   removePlace,
   removePlaceDescription,
   removePlaceInputSchema,
@@ -247,6 +257,26 @@ export function buildServer(ctx: AppContext): McpServer {
       inputSchema: removePlaceInputSchema,
     },
     requireAuth(ctx, async (args) => removePlace(ctx, args as Parameters<typeof removePlace>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_remove_note",
+    {
+      title: "Remove a note from a Wanderlog trip",
+      description: removeNoteDescription,
+      inputSchema: removeNoteInputSchema,
+    },
+    requireAuth(ctx, async (args) => removeNote(ctx, args as Parameters<typeof removeNote>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_edit_note",
+    {
+      title: "Edit an existing note's text in place",
+      description: editNoteDescription,
+      inputSchema: editNoteInputSchema,
+    },
+    requireAuth(ctx, async (args) => editNote(ctx, args as Parameters<typeof editNote>[1])),
   );
 
   server.registerTool(

--- a/src/tools/edit-note.ts
+++ b/src/tools/edit-note.ts
@@ -1,0 +1,131 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { resolveNoteRef } from "../resolvers/note-ref.js";
+import { quillToPlain } from "../types.js";
+import { submitOp } from "./shared.js";
+
+export const editNoteInputSchema = {
+  trip_key: z.string().min(1).describe("The trip containing the note."),
+  note_ref: z
+    .string()
+    .min(1)
+    .describe(
+      "Natural-language reference to the note you want to edit. Same forms as wanderlog_remove_note: substring of the note text ('coach tour'), role keyword ('the note'), day filter ('coach tour on May 6'), ordinal prefix for duplicates ('1st note', 'last note'), or combinations ('2nd note on day 4').",
+    ),
+  text: z
+    .string()
+    .min(1)
+    .describe("The new note text. Plain text — can be multi-line. Replaces the existing text entirely."),
+};
+
+export const editNoteDescription = `
+Replaces the text of an existing note in a Wanderlog trip, in place. The note keeps its
+position in the day's block list — preferred over remove_note + add_note, which forces a
+full rewrite and re-inserts the note at the end of the day, breaking original ordering.
+
+Resolves the target note via the same natural-language references as wanderlog_remove_note.
+If the reference is ambiguous (multiple notes match), the tool returns a numbered list of
+candidates and does NOT make any change. Re-call with an ordinal prefix or a more specific
+substring.
+
+Use this for stale or partially-correct notes. For freshly added notes you don't yet have a
+reference for, prefer including the final text on the original add_note call.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  note_ref: string;
+  text: string;
+};
+
+export async function editNote(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const result = resolveNoteRef(trip, args.note_ref);
+
+    if (result.kind === "none") {
+      throw new WanderlogNotFoundError("Note", args.note_ref);
+    }
+
+    if (result.kind === "ambiguous") {
+      const lines = result.candidates
+        .slice(0, 10)
+        .map((c, i) => {
+          const preview = notePreview(c.block.text);
+          const where = formatLocation(c.section);
+          const ordinal = ordinalLabel(i + 1);
+          return `  ${i + 1}. "${preview}" — ${where} (${ordinal})`;
+        })
+        .join("\n");
+
+      const retryHint =
+        'Call this tool again with an ordinal to pick one, e.g. note_ref: "1st note" or "last note". You can also combine with a day filter, e.g. "2nd note on day 2", or refine the substring.';
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.note_ref}" matches ${result.candidates.length} notes:\n${lines}\n\n${retryHint}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { sectionIndex, blockIndex, block, section } = result.match;
+    const oldLength = quillToPlain(block.text).length;
+    const newText = `${args.text}\n`;
+
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex, "text"],
+        t: "rich-text",
+        o: oldLength > 0
+          ? [{ delete: oldLength }, { insert: newText }]
+          : [{ insert: newText }],
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const preview = args.text.length > 60 ? `${args.text.slice(0, 57)}…` : args.text;
+    const text = `Updated note in ${formatLocation(section)} of "${trip.title}" to "${preview}".`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}
+
+function notePreview(text: { ops?: Array<{ insert?: string }> } | undefined): string {
+  const plain = quillToPlain(text).replace(/\s+/g, " ").trim();
+  if (plain.length <= 60) return plain;
+  return `${plain.slice(0, 57)}…`;
+}
+
+function formatLocation(section: {
+  heading?: string;
+  type?: string;
+  mode?: string;
+  date?: string | null;
+}): string {
+  if (section.mode === "dayPlan" && section.date) {
+    return `day ${section.date}`;
+  }
+  if (section.heading) return `"${section.heading}"`;
+  return `"${section.type ?? "section"}"`;
+}
+
+function ordinalLabel(n: number): string {
+  const suffix = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${suffix[(v - 20) % 10] ?? suffix[v] ?? suffix[0]}`;
+}

--- a/src/tools/remove-note.ts
+++ b/src/tools/remove-note.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { resolveNoteRef } from "../resolvers/note-ref.js";
+import { quillToPlain } from "../types.js";
+import { submitOp } from "./shared.js";
+
+export const removeNoteInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to remove the note from."),
+  note_ref: z
+    .string()
+    .min(1)
+    .describe(
+      "Natural-language reference to the note you want to remove. Examples: 'coach tour' (substring of the note text), 'the note' (if the trip has exactly one note), 'milford prep on day 3'. Supports ordinal prefixes for duplicates: '1st note', 'second note on day 2', 'last note'. Supports day filters via ' on ': 'coach tour on May 6'.",
+    ),
+};
+
+export const removeNoteDescription = `
+Removes a note block from a Wanderlog trip, resolved by natural-language reference.
+
+Supported reference forms:
+  - Substring of the note text (case-insensitive): "coach tour", "milford"
+  - Role keyword: "the note" / "note" — picks the only note in scope, or returns
+    a numbered list if there are multiple
+  - Day filter: "coach tour on May 6" or "... on day 3"
+  - Ordinal prefix for duplicates: "1st note", "second note", "last milford"
+  - Combined: "2nd note on day 4"
+
+If the reference is ambiguous (multiple notes match), the tool returns a numbered
+list of candidates and does NOT make any change. Re-call with an ordinal prefix or
+a more specific substring.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  note_ref: string;
+};
+
+export async function removeNote(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const result = resolveNoteRef(trip, args.note_ref);
+
+    if (result.kind === "none") {
+      throw new WanderlogNotFoundError("Note", args.note_ref);
+    }
+
+    if (result.kind === "ambiguous") {
+      const lines = result.candidates
+        .slice(0, 10)
+        .map((c, i) => {
+          const preview = notePreview(c.block.text);
+          const where = formatLocation(c.section);
+          const ordinal = ordinalLabel(i + 1);
+          return `  ${i + 1}. "${preview}" — ${where} (${ordinal})`;
+        })
+        .join("\n");
+
+      const retryHint =
+        'Call this tool again with an ordinal to pick one, e.g. note_ref: "1st note" or "last note". You can also combine with a day filter, e.g. "2nd note on day 2", or refine the substring.';
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.note_ref}" matches ${result.candidates.length} notes:\n${lines}\n\n${retryHint}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { sectionIndex, blockIndex, block, section } = result.match;
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex],
+        ld: block,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const preview = notePreview(block.text);
+    const text = `Removed note "${preview}" from ${formatLocation(section)} in "${trip.title}".`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}
+
+function notePreview(text: { ops?: Array<{ insert?: string }> } | undefined): string {
+  const plain = quillToPlain(text).replace(/\s+/g, " ").trim();
+  if (plain.length <= 60) return plain;
+  return `${plain.slice(0, 57)}…`;
+}
+
+function formatLocation(section: {
+  heading?: string;
+  type?: string;
+  mode?: string;
+  date?: string | null;
+}): string {
+  if (section.mode === "dayPlan" && section.date) {
+    return `day ${section.date}`;
+  }
+  if (section.heading) return `"${section.heading}"`;
+  return `"${section.type ?? "section"}"`;
+}
+
+function ordinalLabel(n: number): string {
+  const suffix = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${suffix[(v - 20) % 10] ?? suffix[v] ?? suffix[0]}`;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,6 +128,18 @@ export function isChecklistBlock(block: Block): block is ChecklistBlock {
   return block.type === "checklist" && "items" in block;
 }
 
+export function isNoteBlock(block: Block): block is NoteBlock {
+  return block.type === "note";
+}
+
+/** Extract plain text from a Quill Delta `{ops: [{insert: "..."}]}`. */
+export function quillToPlain(delta: QuillDelta | undefined): string {
+  if (!delta?.ops) return "";
+  return delta.ops
+    .map((op) => (typeof op.insert === "string" ? op.insert : ""))
+    .join("");
+}
+
 export type SectionType =
   | "textOnly"
   | "normal"

--- a/tests/fixtures/notes-trip.ts
+++ b/tests/fixtures/notes-trip.ts
@@ -1,0 +1,89 @@
+import type { TripPlan } from "../../src/types.ts";
+
+/**
+ * Fixture with multiple notes across days and the placeList section. Used to
+ * exercise the note-ref resolver's substring / ordinal / day-filter logic.
+ *
+ * Notes layout:
+ *   - Places-to-visit ("Notes" section): one "pre-trip checklist reminder" note
+ *   - Day 2026-05-06: two notes — "coach tour departure" and "coach tour return"
+ *   - Day 2026-05-07: one "anniversary dinner" note
+ */
+export const notesTrip: TripPlan = {
+  id: 99999999,
+  key: "notestriptestkey",
+  editKey: "notestriptestkey",
+  viewKey: "vvvvvvvvv",
+  suggestKey: "ssssssssss",
+  title: "Notes Fixture Trip",
+  userId: 3656632,
+  privacy: "private",
+  startDate: "2026-05-06",
+  endDate: "2026-05-07",
+  days: 2,
+  placeCount: 0,
+  schemaVersion: 2,
+  createdAt: "2026-04-20T00:00:00Z",
+  updatedAt: "2026-04-20T00:00:00Z",
+  contributors: [{ id: 3656632, username: "ali", name: "Ali" }],
+  editors: [{ id: 3656632, username: "ali", name: "Ali" }],
+  itinerary: {
+    sections: [
+      {
+        id: 1,
+        type: "textOnly",
+        mode: "placeList",
+        heading: "Notes",
+        date: null,
+        blocks: [
+          {
+            id: 5001,
+            type: "note",
+            text: { ops: [{ insert: "Pre-trip checklist reminder: pack warm layers\n" }] },
+            addedBy: { type: "user", userId: 3656632 },
+            attachments: [],
+          },
+        ],
+      },
+      {
+        id: 2,
+        type: "normal",
+        mode: "dayPlan",
+        heading: "",
+        date: "2026-05-06",
+        blocks: [
+          {
+            id: 5002,
+            type: "note",
+            text: { ops: [{ insert: "Coach tour departure — 07:00 from Queenstown\n" }] },
+            addedBy: { type: "user", userId: 3656632 },
+            attachments: [],
+          },
+          {
+            id: 5003,
+            type: "note",
+            text: { ops: [{ insert: "Coach tour return — back by 19:30\n" }] },
+            addedBy: { type: "user", userId: 3656632 },
+            attachments: [],
+          },
+        ],
+      },
+      {
+        id: 3,
+        type: "normal",
+        mode: "dayPlan",
+        heading: "",
+        date: "2026-05-07",
+        blocks: [
+          {
+            id: 5004,
+            type: "note",
+            text: { ops: [{ insert: "Anniversary dinner — book 2 weeks ahead\n" }] },
+            addedBy: { type: "user", userId: 3656632 },
+            attachments: [],
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/tests/integration/mutations.test.ts
+++ b/tests/integration/mutations.test.ts
@@ -3,9 +3,11 @@ import { createContext, type AppContext } from "../../src/context.ts";
 import { addChecklist } from "../../src/tools/add-checklist.ts";
 import { addHotel } from "../../src/tools/add-hotel.ts";
 import { addNote } from "../../src/tools/add-note.ts";
+import { editNote } from "../../src/tools/edit-note.ts";
 import { addPlace } from "../../src/tools/add-place.ts";
 import { createTrip } from "../../src/tools/create-trip.ts";
 import { getTrip } from "../../src/tools/get-trip.ts";
+import { removeNote } from "../../src/tools/remove-note.ts";
 import { removePlace } from "../../src/tools/remove-place.ts";
 import { updateTripDates } from "../../src/tools/update-trip-dates.ts";
 import { isChecklistBlock, isPlaceBlock } from "../../src/types.ts";
@@ -154,6 +156,57 @@ describe("Mutation tools (live round-trip)", () => {
     expect(result.content[0]!.text).toContain("places to visit");
   }, 30_000);
 
+  it("edit_note replaces the 'General trip reminder' text in place", async () => {
+    expect(tripKey).toBeDefined();
+    const newText = "General trip reminder — updated via edit_note";
+    const result = await editNote(ctx, {
+      trip_key: tripKey!,
+      note_ref: "general trip reminder",
+      text: newText,
+    });
+    if (result.isError) {
+      throw new Error(`edit_note failed: ${result.content[0]!.text}`);
+    }
+    expect(result.content[0]!.text.toLowerCase()).toContain("updated");
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    const updated = trip.itinerary.sections
+      .flatMap((s) => s.blocks)
+      .find(
+        (b) =>
+          b.type === "note" &&
+          ((b as NoteBlock).text?.ops ?? []).some(
+            (op) => typeof op.insert === "string" && op.insert.includes("updated via edit_note"),
+          ),
+      );
+    expect(updated).toBeDefined();
+
+    const stale = trip.itinerary.sections
+      .flatMap((s) => s.blocks)
+      .some(
+        (b) =>
+          b.type === "note" &&
+          ((b as NoteBlock).text?.ops ?? []).some(
+            (op) => typeof op.insert === "string" && op.insert.trim() === "General trip reminder",
+          ),
+      );
+    expect(stale).toBe(false);
+  }, 30_000);
+
+  it("edit_note returns ambiguous candidates without mutating when ref matches multiple", async () => {
+    expect(tripKey).toBeDefined();
+    // Day 1 has the "sunscreen" note; the placeList has the now-updated reminder.
+    // Both contain the substring "trip" in some form? Use role keyword on placeList instead:
+    // we expect "note" alone to be ambiguous since at least 2 notes exist on the trip.
+    const result = await editNote(ctx, {
+      trip_key: tripKey!,
+      note_ref: "note",
+      text: "should not be applied",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text.toLowerCase()).toMatch(/matches \d+ notes/);
+  }, 20_000);
+
   it("add_checklist adds a checklist with title and items to day 2", async () => {
     expect(tripKey).toBeDefined();
     const result = await addChecklist(ctx, {
@@ -204,6 +257,62 @@ describe("Mutation tools (live round-trip)", () => {
     const result = await removePlace(ctx, {
       trip_key: tripKey!,
       place_ref: "definitely not a real place xyzzy",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text.toLowerCase()).toMatch(/not found/);
+  });
+
+  it("remove_note removes the sunscreen note by substring", async () => {
+    expect(tripKey).toBeDefined();
+    const result = await removeNote(ctx, {
+      trip_key: tripKey!,
+      note_ref: "sunscreen",
+    });
+    if (result.isError) {
+      throw new Error(`remove_note failed: ${result.content[0]!.text}`);
+    }
+    expect(result.content[0]!.text.toLowerCase()).toContain("removed");
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    const stillThere = trip.itinerary.sections.some((s) =>
+      s.blocks.some(
+        (b) =>
+          b.type === "note" &&
+          ((b as NoteBlock).text?.ops ?? []).some(
+            (op) => typeof op.insert === "string" && op.insert.includes("sunscreen"),
+          ),
+      ),
+    );
+    expect(stillThere).toBe(false);
+  }, 30_000);
+
+  it("remove_note 'the note' is ambiguous when multiple notes exist", async () => {
+    // At this point at least the 'General trip reminder' note remains; the
+    // test trip may also have picked up other notes from live churn. We only
+    // require that calling with "note" on a trip with >=2 notes returns an
+    // ambiguous response without mutating. Add a second note to guarantee it.
+    expect(tripKey).toBeDefined();
+    const seedResult = await addNote(ctx, {
+      trip_key: tripKey!,
+      text: "Second remover probe note",
+    });
+    if (seedResult.isError) {
+      throw new Error(`seed add_note failed: ${seedResult.content[0]!.text}`);
+    }
+
+    const result = await removeNote(ctx, {
+      trip_key: tripKey!,
+      note_ref: "note",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text.toLowerCase()).toMatch(/matches \d+ notes/);
+  }, 30_000);
+
+  it("remove_note returns not-found for an unmatched ref", async () => {
+    expect(tripKey).toBeDefined();
+    const result = await removeNote(ctx, {
+      trip_key: tripKey!,
+      note_ref: "this note text definitely does not exist xyzzy",
     });
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text.toLowerCase()).toMatch(/not found/);

--- a/tests/unit/edit-note.test.ts
+++ b/tests/unit/edit-note.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import { resolveNoteRef } from "../../src/resolvers/note-ref.ts";
+import { quillToPlain, type TripPlan } from "../../src/types.ts";
+import { notesTrip } from "../fixtures/notes-trip.ts";
+
+function fresh(trip: TripPlan): TripPlan {
+  return structuredClone(trip);
+}
+
+/**
+ * Builds the rich-text replacement op the same way `editNote` does. Kept here
+ * so the test asserts on the exact op shape submitted to ShareDB without
+ * needing an AppContext + transport mock.
+ */
+function buildEditOp(
+  trip: TripPlan,
+  note_ref: string,
+  newText: string,
+): Json0Op[] {
+  const result = resolveNoteRef(trip, note_ref);
+  if (result.kind !== "unique") {
+    throw new Error(`expected unique resolution, got ${result.kind}`);
+  }
+  const { sectionIndex, blockIndex, block } = result.match;
+  const oldLength = quillToPlain(block.text).length;
+  const body = `${newText}\n`;
+  return [
+    {
+      p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex, "text"],
+      t: "rich-text",
+      o: oldLength > 0 ? [{ delete: oldLength }, { insert: body }] : [{ insert: body }],
+    },
+  ];
+}
+
+describe("editNote rich-text op", () => {
+  it("replaces the entire text of a uniquely-resolved note", () => {
+    const trip = fresh(notesTrip);
+    const ops = buildEditOp(trip, "anniversary", "Anniversary dinner — confirmed at Rata, 19:00");
+
+    const next = applyOp(trip, ops) as TripPlan;
+    const updated = next.itinerary.sections[2]!.blocks[0]!;
+    expect(updated.type).toBe("note");
+    if (updated.type !== "note") return;
+    expect(quillToPlain(updated.text)).toBe("Anniversary dinner — confirmed at Rata, 19:00\n");
+  });
+
+  it("preserves the note's position in the day's block list", () => {
+    const trip = fresh(notesTrip);
+    const ops = buildEditOp(trip, "1st coach tour", "Coach pickup — 06:45 sharp at Steamer Wharf");
+
+    const next = applyOp(trip, ops) as TripPlan;
+    const day = next.itinerary.sections[1]!;
+    expect(day.blocks).toHaveLength(2);
+    expect(day.blocks[0]!.id).toBe(5002);
+    expect(day.blocks[1]!.id).toBe(5003);
+
+    const first = day.blocks[0]!;
+    if (first.type !== "note") throw new Error("expected note");
+    expect(quillToPlain(first.text)).toBe("Coach pickup — 06:45 sharp at Steamer Wharf\n");
+
+    const second = day.blocks[1]!;
+    if (second.type !== "note") throw new Error("expected note");
+    expect(quillToPlain(second.text)).toBe("Coach tour return — back by 19:30\n");
+  });
+
+  it("targets the text field (not the block) so the block id and addedBy survive", () => {
+    const trip = fresh(notesTrip);
+    const ops = buildEditOp(trip, "anniversary", "new text");
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      2,
+      "blocks",
+      0,
+      "text",
+    ]);
+    expect(ops[0]!.t).toBe("rich-text");
+
+    const next = applyOp(trip, ops) as TripPlan;
+    const updated = next.itinerary.sections[2]!.blocks[0]!;
+    expect(updated.id).toBe(5004);
+    if (updated.type !== "note") return;
+    expect(updated.addedBy).toEqual({ type: "user", userId: 3656632 });
+  });
+});

--- a/tests/unit/note-ref.test.ts
+++ b/tests/unit/note-ref.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { resolveNoteRef } from "../../src/resolvers/note-ref.ts";
+import { quillToPlain } from "../../src/types.ts";
+import { notesTrip } from "../fixtures/notes-trip.ts";
+
+describe("resolveNoteRef", () => {
+  it("matches a unique substring in one note", () => {
+    const result = resolveNoteRef(notesTrip, "anniversary");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(quillToPlain(result.match.block.text)).toContain("Anniversary dinner");
+    expect(result.match.section.date).toBe("2026-05-07");
+  });
+
+  it("is case-insensitive", () => {
+    const result = resolveNoteRef(notesTrip, "ANNIVERSARY");
+    expect(result.kind).toBe("unique");
+  });
+
+  it("returns ambiguous when the substring matches multiple notes", () => {
+    const result = resolveNoteRef(notesTrip, "coach tour");
+    expect(result.kind).toBe("ambiguous");
+    if (result.kind !== "ambiguous") return;
+    expect(result.candidates).toHaveLength(2);
+  });
+
+  it("disambiguates with ordinal prefix '1st'", () => {
+    const result = resolveNoteRef(notesTrip, "1st coach tour");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(quillToPlain(result.match.block.text)).toContain("departure");
+  });
+
+  it("disambiguates with word ordinal 'second'", () => {
+    const result = resolveNoteRef(notesTrip, "second coach tour");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(quillToPlain(result.match.block.text)).toContain("return");
+  });
+
+  it("disambiguates with 'last'", () => {
+    const result = resolveNoteRef(notesTrip, "last coach tour");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(quillToPlain(result.match.block.text)).toContain("return");
+  });
+
+  it("filters by day via ' on <date>'", () => {
+    const result = resolveNoteRef(notesTrip, "coach tour on May 6");
+    expect(result.kind).toBe("ambiguous"); // still two coach-tour notes, both on May 6
+    if (result.kind !== "ambiguous") return;
+    expect(result.candidates).toHaveLength(2);
+    for (const c of result.candidates) {
+      expect(c.section.date).toBe("2026-05-06");
+    }
+  });
+
+  it("filters by day and resolves uniquely when a day has one match", () => {
+    const result = resolveNoteRef(notesTrip, "note on May 7");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(quillToPlain(result.match.block.text)).toContain("Anniversary");
+  });
+
+  it("combines ordinal + day filter", () => {
+    const result = resolveNoteRef(notesTrip, "2nd coach tour on day 1");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(quillToPlain(result.match.block.text)).toContain("return");
+  });
+
+  it("resolves role keyword 'note' — ambiguous across the whole trip", () => {
+    const result = resolveNoteRef(notesTrip, "note");
+    expect(result.kind).toBe("ambiguous");
+    if (result.kind !== "ambiguous") return;
+    expect(result.candidates).toHaveLength(4);
+  });
+
+  it("resolves 'the note on day 2' — uniquely on the anniversary day", () => {
+    const result = resolveNoteRef(notesTrip, "the note on day 2");
+    expect(result.kind).toBe("unique");
+    if (result.kind !== "unique") return;
+    expect(result.match.section.date).toBe("2026-05-07");
+  });
+
+  it("returns none for an unmatched ref", () => {
+    const result = resolveNoteRef(notesTrip, "does not appear anywhere");
+    expect(result.kind).toBe("none");
+  });
+
+  it("returns none when ordinal overflows candidate count", () => {
+    const result = resolveNoteRef(notesTrip, "5th coach tour");
+    expect(result.kind).toBe("none");
+  });
+
+  it("returns none for empty ref", () => {
+    expect(resolveNoteRef(notesTrip, "").kind).toBe("none");
+    expect(resolveNoteRef(notesTrip, "   ").kind).toBe("none");
+  });
+
+  it("ignores non-note blocks when matching", () => {
+    // Trip has no places, but the textOnly "Notes" section is populated with notes.
+    // The role keyword must not pick up a place even if this trip had one.
+    const result = resolveNoteRef(notesTrip, "note");
+    if (result.kind !== "ambiguous") return;
+    for (const c of result.candidates) {
+      expect(c.block.type).toBe("note");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New `wanderlog_remove_note` and `wanderlog_edit_note` tools, both targeting notes via natural-language references through a shared `resolveNoteRef` resolver (substring / role / day-filter / ordinal — same shapes as `place-ref`).
- `edit_note` replaces a note's text in place via a `rich-text` subtype op (`[{delete: oldLength}, {insert: newText+'\n'}]`), preserving the block id, `addedBy`, and position. Fixes the regression where `remove_note` + `add_note` re-ordered notes to the end of the day's block list.
- `quillToPlain` and `isNoteBlock` lifted from `trip-summary.ts` into `types.ts` so resolvers and tools can share them.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 215 unit tests pass (includes 15 new for `note-ref`, 3 new for `edit-note`)
- [x] `npm run test:integration` — `mutations.test.ts` passes 17/17 including 5 new live tests:
  - `remove_note removes the sunscreen note by substring`
  - `remove_note 'the note' is ambiguous when multiple notes exist`
  - `remove_note returns not-found for an unmatched ref`
  - `edit_note replaces the 'General trip reminder' text in place`
  - `edit_note returns ambiguous candidates without mutating when ref matches multiple`
- [x] Verified `edit_note` round-trips end-to-end against the live Wanderlog REST snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)