### PR TITLE
feat: add wanderlog_remove_note and wanderlog_edit_note tools

### DIFF
--- a/src/resolvers/place-ref.ts
+++ b/src/resolvers/place-ref.ts
@@ -231,5 +231,7 @@ function finalize(candidates: PlaceRefMatch[]): PlaceRefResult {
 }
 
 function normalize(s: string): string {
-  return s.replace(/\s+/g, " ").trim().toLowerCase();
+  // Collapse runs of whitespace and punctuation dashes (hyphens, en/em-dashes)
+  // so "Roppongi Hills - Tokyo City View" matches "Roppongi Hills Tokyo City View".
+  return s.replace(/[\s\-–—]+/g, " ").trim().toLowerCase();
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -71,6 +71,11 @@ import {
   renameDayInputSchema,
 } from "./tools/rename-day.js";
 import {
+  editNote,
+  editNoteDescription,
+  editNoteInputSchema,
+} from "./tools/edit-note.js";
+import {
   removeNote,
   removeNoteDescription,
   removeNoteInputSchema,
@@ -252,6 +257,16 @@ export function buildServer(ctx: AppContext): McpServer {
       inputSchema: removePlaceInputSchema,
     },
     requireAuth(ctx, async (args) => removePlace(ctx, args as Parameters<typeof removePlace>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_edit_note",
+    {
+      title: "Edit note content in a Wanderlog trip",
+      description: editNoteDescription,
+      inputSchema: editNoteInputSchema,
+    },
+    requireAuth(ctx, async (args) => editNote(ctx, args as Parameters<typeof editNote>[1])),
   );
 
   server.registerTool(

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,6 +70,11 @@ import {
   renameDayDescription,
   renameDayInputSchema,
 } from "./tools/rename-day.js";
+import {
+  removeNote,
+  removeNoteDescription,
+  removeNoteInputSchema,
+} from "./tools/remove-note.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -247,6 +252,16 @@ export function buildServer(ctx: AppContext): McpServer {
       inputSchema: removePlaceInputSchema,
     },
     requireAuth(ctx, async (args) => removePlace(ctx, args as Parameters<typeof removePlace>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_remove_note",
+    {
+      title: "Remove a note from a Wanderlog trip",
+      description: removeNoteDescription,
+      inputSchema: removeNoteInputSchema,
+    },
+    requireAuth(ctx, async (args) => removeNote(ctx, args as Parameters<typeof removeNote>[1])),
   );
 
   server.registerTool(

--- a/src/tools/edit-note.ts
+++ b/src/tools/edit-note.ts
@@ -1,0 +1,270 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { resolveDay } from "../resolvers/day.js";
+import type { ChecklistBlock, NoteBlock, QuillDelta, TripPlan } from "../types.js";
+import { isChecklistBlock, isPlaceBlock } from "../types.js";
+import { findDaySectionByDate, submitOp } from "./shared.js";
+import { extractDeltaText } from "./remove-note.js";
+
+export const editNoteInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to edit."),
+  old_text: z
+    .string()
+    .min(1)
+    .describe("Substring to find and replace (case-insensitive)."),
+  new_text: z.string().describe("Replacement text."),
+  day: z
+    .string()
+    .optional()
+    .describe(
+      "Optional day to search. Accepts 'day 2', 'May 4', or ISO '2026-05-04'. Omit to search the entire trip.",
+    ),
+};
+
+export const editNoteDescription = `
+Edits note content in a Wanderlog trip by finding and replacing a substring.
+
+Searches across freestanding notes, place annotations, and checklist titles and items.
+The match is case-insensitive. If exactly one match is found, the replacement is made in place.
+If no matches are found, an error is returned. If multiple matches are found, a numbered list
+of previews is returned — call again with a more specific substring.
+
+Use the optional 'day' filter to limit the search to a specific day.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  old_text: string;
+  new_text: string;
+  day?: string;
+};
+
+type RichTextTarget = {
+  kind: "rich-text";
+  label: string;
+  preview: string;
+  sectionIndex: number;
+  blockIndex: number;
+  fieldPath: (string | number)[];
+  offset: number;
+  matchedLen: number;
+  crossesBoundary: boolean;
+};
+
+type PlainTarget = {
+  kind: "plain";
+  label: string;
+  preview: string;
+  sectionIndex: number;
+  blockIndex: number;
+  fieldPath: (string | number)[];
+  oldValue: string;
+  offset: number;
+  matchedLen: number;
+};
+
+export type EditTarget = RichTextTarget | PlainTarget;
+
+function previewText(text: string): string {
+  const flat = text.replace(/\n/g, " ").trim();
+  return flat.length > 60 ? `${flat.slice(0, 57)}…` : flat;
+}
+
+function matchInDelta(
+  delta: QuillDelta | undefined,
+  query: string,
+): { offset: number; matchedLen: number; crossesBoundary: boolean } | null {
+  const ops = delta?.ops ?? [];
+  const lowerQuery = query.toLowerCase();
+  const boundaries: number[] = [];
+  let plainText = "";
+  for (const op of ops) {
+    boundaries.push(plainText.length);
+    plainText += typeof op.insert === "string" ? op.insert : "";
+  }
+  const lowerText = plainText.toLowerCase();
+  const matchStart = lowerText.indexOf(lowerQuery);
+  if (matchStart === -1) return null;
+  const matchEnd = matchStart + lowerQuery.length;
+  const crossesBoundary = boundaries.some((b) => b > matchStart && b < matchEnd);
+  return { offset: matchStart, matchedLen: lowerQuery.length, crossesBoundary };
+}
+
+export function findEditTargets(trip: TripPlan, query: string, day?: string): EditTarget[] {
+  const sections = trip.itinerary.sections;
+  const targets: EditTarget[] = [];
+  const lowerQuery = query.toLowerCase();
+
+  let sectionIndices: number[];
+  if (day) {
+    const resolved = resolveDay(trip, day);
+    const found = findDaySectionByDate(trip, resolved.date!);
+    if (!found) return [];
+    sectionIndices = [found.index];
+  } else {
+    sectionIndices = Array.from({ length: sections.length }, (_, i) => i);
+  }
+
+  for (const si of sectionIndices) {
+    const section = sections[si]!;
+    for (let bi = 0; bi < section.blocks.length; bi++) {
+      const block = section.blocks[bi]!;
+      const blockBase: (string | number)[] = ["itinerary", "sections", si, "blocks", bi];
+
+      if (block.type === "note") {
+        const delta = (block as NoteBlock).text;
+        const m = matchInDelta(delta, query);
+        if (m) {
+          targets.push({
+            kind: "rich-text",
+            label: "note",
+            preview: `Note: "${previewText(extractDeltaText(delta))}"`,
+            sectionIndex: si,
+            blockIndex: bi,
+            fieldPath: [...blockBase, "text"],
+            offset: m.offset,
+            matchedLen: m.matchedLen,
+            crossesBoundary: m.crossesBoundary,
+          });
+        }
+      } else if (isPlaceBlock(block)) {
+        const delta = block.text;
+        if (delta) {
+          const m = matchInDelta(delta, query);
+          if (m) {
+            targets.push({
+              kind: "rich-text",
+              label: `"${block.place.name}" annotation`,
+              preview: `"${block.place.name}" annotation: "${previewText(extractDeltaText(delta))}"`,
+              sectionIndex: si,
+              blockIndex: bi,
+              fieldPath: [...blockBase, "text"],
+              offset: m.offset,
+              matchedLen: m.matchedLen,
+              crossesBoundary: m.crossesBoundary,
+            });
+          }
+        }
+      } else if (isChecklistBlock(block)) {
+        const cb = block as ChecklistBlock;
+        // Checklist title (plain string)
+        const title = cb.title ?? "";
+        if (title && title.toLowerCase().includes(lowerQuery)) {
+          const offset = title.toLowerCase().indexOf(lowerQuery);
+          targets.push({
+            kind: "plain",
+            label: "checklist title",
+            preview: `Checklist title: "${previewText(title)}"`,
+            sectionIndex: si,
+            blockIndex: bi,
+            fieldPath: [...blockBase, "title"],
+            oldValue: title,
+            offset,
+            matchedLen: query.length,
+          });
+        }
+        // Checklist items
+        for (let ii = 0; ii < cb.items.length; ii++) {
+          const item = cb.items[ii]!;
+          const m = matchInDelta(item.text, query);
+          if (m) {
+            targets.push({
+              kind: "rich-text",
+              label: "checklist item",
+              preview: `Checklist item: "${previewText(extractDeltaText(item.text))}"`,
+              sectionIndex: si,
+              blockIndex: bi,
+              fieldPath: [...blockBase, "items", ii, "text"],
+              offset: m.offset,
+              matchedLen: m.matchedLen,
+              crossesBoundary: m.crossesBoundary,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return targets;
+}
+
+export async function editNote(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const targets = findEditTargets(trip, args.old_text, args.day);
+
+    if (targets.length === 0) {
+      throw new WanderlogNotFoundError("Note", args.old_text);
+    }
+
+    if (targets.length > 1) {
+      const lines = targets
+        .slice(0, 5)
+        .map((t, i) => `  ${i + 1}. ${t.preview}`)
+        .join("\n");
+      const suffix = targets.length > 5 ? `\n  (${targets.length - 5} more…)` : "";
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.old_text}" matches ${targets.length} notes:\n${lines}${suffix}\n\nCall again with a more specific substring to identify the one you want.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const target = targets[0]!;
+
+    if (target.kind === "rich-text" && target.crossesBoundary) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Cannot replace "${args.old_text}": the match crosses a formatting boundary (e.g. a link or bold section). Use a more specific substring that stays within one formatting run.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    let ops: Json0Op[];
+    if (target.kind === "rich-text") {
+      const deltaOps: Array<Record<string, unknown>> = [];
+      if (target.offset > 0) deltaOps.push({ retain: target.offset });
+      deltaOps.push({ delete: target.matchedLen });
+      if (args.new_text) deltaOps.push({ insert: args.new_text });
+      ops = [{ p: target.fieldPath, t: "rich-text", o: deltaOps }];
+    } else {
+      const newValue =
+        target.oldValue.slice(0, target.offset) +
+        args.new_text +
+        target.oldValue.slice(target.offset + target.matchedLen);
+      ops = [{ p: target.fieldPath, od: target.oldValue, oi: newValue }];
+    }
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const oldPreview = previewText(args.old_text);
+    const newPreview = previewText(args.new_text || "(empty)");
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Updated ${target.label} in "${trip.title}". Changed "${oldPreview}" → "${newPreview}".`,
+        },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/remove-note.ts
+++ b/src/tools/remove-note.ts
@@ -3,7 +3,7 @@ import type { AppContext } from "../context.js";
 import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import { resolveDay } from "../resolvers/day.js";
-import type { NoteBlock, TripPlan } from "../types.js";
+import type { NoteBlock, QuillDelta, TripPlan } from "../types.js";
 import { findDaySectionByDate, submitOp } from "./shared.js";
 
 export const removeNoteInputSchema = {
@@ -43,9 +43,13 @@ export type NoteMatch = {
   block: NoteBlock;
 };
 
+export function extractDeltaText(delta: QuillDelta | undefined): string {
+  const ops = delta?.ops ?? [];
+  return ops.map((op) => (typeof op.insert === "string" ? op.insert : "")).join("");
+}
+
 export function extractPlainText(block: NoteBlock): string {
-  const ops = block.text?.ops ?? [];
-  return ops.map((op) => op.insert ?? "").join("");
+  return extractDeltaText(block.text);
 }
 
 export function findNoteMatches(trip: TripPlan, query: string, day?: string): NoteMatch[] {

--- a/src/tools/remove-note.ts
+++ b/src/tools/remove-note.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { resolveDay } from "../resolvers/day.js";
+import type { NoteBlock, TripPlan } from "../types.js";
+import { findDaySectionByDate, submitOp } from "./shared.js";
+
+export const removeNoteInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to remove from."),
+  text: z
+    .string()
+    .min(1)
+    .describe("Substring to match against note content (case-insensitive)."),
+  day: z
+    .string()
+    .optional()
+    .describe(
+      "Optional day to search. Accepts 'day 2', 'May 4', or ISO '2026-05-04'. Omit to search the entire trip.",
+    ),
+};
+
+export const removeNoteDescription = `
+Removes a note block from a Wanderlog trip by matching a substring of its text content.
+
+The match is case-insensitive. If exactly one note matches, it is deleted. If no notes match,
+an error is returned. If multiple notes match, a list of previews is returned — supply a more
+specific substring to narrow to one.
+
+Use the optional 'day' filter to limit the search to a specific day.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  text: string;
+  day?: string;
+};
+
+export type NoteMatch = {
+  sectionIndex: number;
+  blockIndex: number;
+  plainText: string;
+  block: NoteBlock;
+};
+
+export function extractPlainText(block: NoteBlock): string {
+  const ops = block.text?.ops ?? [];
+  return ops.map((op) => op.insert ?? "").join("");
+}
+
+export function findNoteMatches(trip: TripPlan, query: string, day?: string): NoteMatch[] {
+  const lowerQuery = query.toLowerCase();
+  const sections = trip.itinerary.sections;
+  const matches: NoteMatch[] = [];
+
+  let sectionIndices: number[];
+  if (day) {
+    const resolved = resolveDay(trip, day);
+    const found = findDaySectionByDate(trip, resolved.date!);
+    if (!found) return [];
+    sectionIndices = [found.index];
+  } else {
+    sectionIndices = Array.from({ length: sections.length }, (_, i) => i);
+  }
+
+  for (const sectionIndex of sectionIndices) {
+    const section = sections[sectionIndex]!;
+    for (let blockIndex = 0; blockIndex < section.blocks.length; blockIndex++) {
+      const block = section.blocks[blockIndex]!;
+      if (block.type !== "note") continue;
+      const noteBlock = block as NoteBlock;
+      const plainText = extractPlainText(noteBlock);
+      if (plainText.toLowerCase().includes(lowerQuery)) {
+        matches.push({ sectionIndex, blockIndex, plainText, block: noteBlock });
+      }
+    }
+  }
+
+  return matches;
+}
+
+function notePreview(plainText: string): string {
+  const flat = plainText.replace(/\n/g, " ").trim();
+  return flat.length > 60 ? `${flat.slice(0, 57)}…` : flat;
+}
+
+export async function removeNote(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const matches = findNoteMatches(trip, args.text, args.day);
+
+    if (matches.length === 0) {
+      throw new WanderlogNotFoundError("Note", args.text);
+    }
+
+    if (matches.length > 1) {
+      const lines = matches
+        .slice(0, 5)
+        .map((m, i) => `  ${i + 1}. "${notePreview(m.plainText)}"`)
+        .join("\n");
+      const suffix = matches.length > 5 ? `\n  (${matches.length - 5} more…)` : "";
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.text}" matches ${matches.length} notes:\n${lines}${suffix}\n\nCall again with a more specific substring to identify the one you want.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { sectionIndex, blockIndex, block, plainText } = matches[0]!;
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex],
+        ld: block,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const text = `Removed note "${notePreview(plainText)}" from "${trip.title}".`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/tests/unit/edit-note.test.ts
+++ b/tests/unit/edit-note.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import type { Json0Op } from "../../src/ot/apply.ts";
+import type { TripPlan } from "../../src/types.ts";
+import {
+  editNote,
+  findEditTargets,
+} from "../../src/tools/edit-note.ts";
+import { checklistTrip } from "../fixtures/checklist-trip.ts";
+import { mixedBlocksTrip } from "../fixtures/mixed-blocks-trip.ts";
+
+function fresh(trip: TripPlan): TripPlan {
+  return structuredClone(trip);
+}
+
+function makeFakeContext(trip: TripPlan): {
+  ctx: AppContext;
+  submittedOps: Json0Op[][];
+  invalidateCount: { value: number };
+} {
+  const submittedOps: Json0Op[][] = [];
+  const invalidateCount = { value: 0 };
+
+  const ctx = {
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      get: async () => structuredClone(trip),
+      applyLocalOp: () => {},
+      invalidate: () => {
+        invalidateCount.value++;
+      },
+    },
+  } as unknown as AppContext;
+
+  return { ctx, submittedOps, invalidateCount };
+}
+
+// ---------------------------------------------------------------------------
+// findEditTargets — note blocks
+// ---------------------------------------------------------------------------
+
+describe("findEditTargets — note blocks", () => {
+  it("finds a note block by substring", () => {
+    const trip = fresh(mixedBlocksTrip);
+    const results = findEditTargets(trip, "nakamise");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.kind).toBe("rich-text");
+    expect(results[0]!.preview).toContain("Note:");
+    expect(results[0]!.preview).toContain("Nakamise");
+  });
+
+  it("is case-insensitive", () => {
+    const trip = fresh(checklistTrip);
+    const results = findEditTargets(trip, "SUNSCREEN");
+    expect(results).toHaveLength(1);
+  });
+
+  it("returns empty array for no match", () => {
+    const trip = fresh(checklistTrip);
+    expect(findEditTargets(trip, "xyz_impossible")).toHaveLength(0);
+  });
+
+  it("returns correct fieldPath for note block", () => {
+    const trip = fresh(checklistTrip);
+    const results = findEditTargets(trip, "sunscreen");
+    expect(results).toHaveLength(1);
+    const target = results[0]!;
+    expect(target.fieldPath).toContain("text");
+    expect(target.fieldPath).toContain("blocks");
+  });
+
+  it("records correct offset for note match", () => {
+    const trip = fresh(mixedBlocksTrip);
+    const results = findEditTargets(trip, "Check out the");
+    expect(results).toHaveLength(1);
+    const target = results[0]!;
+    expect(target.offset).toBe(0);
+    expect(target.matchedLen).toBe("Check out the".length);
+  });
+
+  it("detects cross-boundary match (span two ops)", () => {
+    const trip = fresh(mixedBlocksTrip);
+    // "Check out the Nakamise" spans op[0] ("Check out the ") and op[1] ("Nakamise...")
+    const results = findEditTargets(trip, "Check out the Nakamise");
+    expect(results).toHaveLength(1);
+    const target = results[0]!;
+    if (target.kind !== "rich-text") throw new Error("expected rich-text");
+    expect(target.crossesBoundary).toBe(true);
+  });
+
+  it("does not flag as cross-boundary when match is within one op", () => {
+    const trip = fresh(mixedBlocksTrip);
+    const results = findEditTargets(trip, "Nakamise shopping street");
+    expect(results).toHaveLength(1);
+    const target = results[0]!;
+    if (target.kind !== "rich-text") throw new Error("expected rich-text");
+    expect(target.crossesBoundary).toBe(false);
+  });
+
+  it("filters by day", () => {
+    const trip = fresh(checklistTrip);
+    const onDay1 = findEditTargets(trip, "sunscreen", "day 1");
+    expect(onDay1).toHaveLength(1);
+    const onDay2 = findEditTargets(trip, "sunscreen", "day 2");
+    expect(onDay2).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findEditTargets — place annotations
+// ---------------------------------------------------------------------------
+
+describe("findEditTargets — place annotations", () => {
+  it("finds place annotation text", () => {
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "dayPlan",
+            heading: "",
+            date: "2026-06-01",
+            blocks: [
+              {
+                id: 50,
+                type: "place",
+                place: {
+                  name: "Sensō-ji",
+                  place_id: "ChIJyyy",
+                  geometry: { location: { lat: 35.71, lng: 139.79 } },
+                },
+                text: { ops: [{ insert: "Arrive before 9am to avoid crowds.\n" }] },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const results = findEditTargets(trip, "avoid crowds");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.kind).toBe("rich-text");
+    expect(results[0]!.preview).toContain("Sensō-ji");
+    expect(results[0]!.label).toContain("Sensō-ji");
+  });
+
+  it("skips place blocks with no text annotation", () => {
+    const trip = fresh(checklistTrip);
+    // Park Güell has no text annotation
+    const results = findEditTargets(trip, "Park");
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findEditTargets — checklist blocks
+// ---------------------------------------------------------------------------
+
+describe("findEditTargets — checklist blocks", () => {
+  it("finds checklist title", () => {
+    const trip = fresh(checklistTrip);
+    const results = findEditTargets(trip, "Packing list");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.kind).toBe("plain");
+    expect(results[0]!.label).toBe("checklist title");
+    expect(results[0]!.preview).toContain("Packing list");
+  });
+
+  it("finds checklist item text", () => {
+    const trip = fresh(checklistTrip);
+    const results = findEditTargets(trip, "Book tickets online");
+    expect(results).toHaveLength(1);
+    expect(results[0]!.kind).toBe("rich-text");
+    expect(results[0]!.label).toBe("checklist item");
+  });
+
+  it("finds checklist item case-insensitively", () => {
+    const trip = fresh(checklistTrip);
+    expect(findEditTargets(trip, "PACK COMFORTABLE")).toHaveLength(1);
+  });
+
+  it("plain target stores correct oldValue and offset", () => {
+    const trip = fresh(checklistTrip);
+    const results = findEditTargets(trip, "Packing");
+    expect(results).toHaveLength(1);
+    const target = results[0]!;
+    if (target.kind !== "plain") throw new Error("expected plain");
+    expect(target.oldValue).toBe("Packing list");
+    expect(target.offset).toBe(0);
+    expect(target.matchedLen).toBe("Packing".length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// editNote handler
+// ---------------------------------------------------------------------------
+
+describe("editNote", () => {
+  it("returns not-found when no match", async () => {
+    const { ctx } = makeFakeContext(checklistTrip);
+    const result = await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "xyz_no_match",
+      new_text: "replacement",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+  });
+
+  it("returns ambiguous list when multiple matches", async () => {
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "placeList",
+            heading: "Notes",
+            date: null,
+            blocks: [
+              { id: 10, type: "note", text: { ops: [{ insert: "Book the restaurant early\n" }] } },
+              { id: 11, type: "note", text: { ops: [{ insert: "Book tickets online\n" }] } },
+            ],
+          },
+        ],
+      },
+    };
+    const { ctx, submittedOps } = makeFakeContext(trip);
+    const result = await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "book",
+      new_text: "reserve",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("matches 2 notes");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("edits a note block with rich-text op", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "sunscreen",
+      new_text: "Neutrogena SPF 50",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("Updated note");
+    expect(result.content[0]!.text).toContain("sunscreen");
+    expect(result.content[0]!.text).toContain("Neutrogena SPF 50");
+    expect(submittedOps).toHaveLength(1);
+    const op = submittedOps[0]![0] as { t: string; o: unknown[] };
+    expect(op.t).toBe("rich-text");
+    const deltaOps = op.o as Array<Record<string, unknown>>;
+    expect(deltaOps.some((d) => "delete" in d)).toBe(true);
+    expect(deltaOps.some((d) => d.insert === "Neutrogena SPF 50")).toBe(true);
+  });
+
+  it("edits a checklist title with plain oi/od op", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "Packing list",
+      new_text: "Pre-trip checklist",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("checklist title");
+    expect(submittedOps).toHaveLength(1);
+    const op = submittedOps[0]![0] as { od: unknown; oi: unknown };
+    expect(op.od).toBe("Packing list");
+    expect(op.oi).toBe("Pre-trip checklist");
+  });
+
+  it("edits a checklist item with rich-text op", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "Book tickets online",
+      new_text: "Buy tickets at the gate",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("checklist item");
+    expect(submittedOps).toHaveLength(1);
+    const op = submittedOps[0]![0] as { t: string };
+    expect(op.t).toBe("rich-text");
+  });
+
+  it("rejects cross-boundary match with clear error", async () => {
+    const { ctx, submittedOps } = makeFakeContext(mixedBlocksTrip);
+    // "Check out the Nakamise" spans two ops
+    const result = await editNote(ctx, {
+      trip_key: "hxziqupjjlmrfrxw",
+      old_text: "Check out the Nakamise",
+      new_text: "Visit the",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("formatting boundary");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("respects day filter", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "sunscreen",
+      new_text: "sunblock",
+      day: "day 2",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("retains text before match (offset > 0)", async () => {
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "dayPlan",
+            heading: "",
+            date: "2026-06-01",
+            blocks: [
+              { id: 10, type: "note", text: { ops: [{ insert: "Please book early.\n" }] } },
+            ],
+          },
+        ],
+      },
+    };
+    const { ctx, submittedOps } = makeFakeContext(trip);
+    await editNote(ctx, {
+      trip_key: "checklisttripkey",
+      old_text: "book",
+      new_text: "reserve",
+    });
+    expect(submittedOps).toHaveLength(1);
+    const deltaOps = (submittedOps[0]![0] as { o: Array<Record<string, unknown>> }).o;
+    // Should have a retain for "Please " prefix
+    expect(deltaOps[0]).toMatchObject({ retain: "Please ".length });
+    expect(deltaOps.some((d) => d.insert === "reserve")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Place-ref normalization (Feature 3) — tested via resolvePlaceRef
+// ---------------------------------------------------------------------------
+
+describe("place-ref punctuation normalization", () => {
+  it("matches hyphenated canonical name against unhyphenated ref", async () => {
+    const { resolvePlaceRef } = await import("../../src/resolvers/place-ref.ts");
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "dayPlan",
+            heading: "",
+            date: "2026-06-01",
+            blocks: [
+              {
+                id: 1,
+                type: "place",
+                place: {
+                  name: "Roppongi Hills - Tokyo City View",
+                  place_id: "ChIJabc",
+                  geometry: { location: { lat: 35.66, lng: 139.73 } },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const result = resolvePlaceRef(trip, "Roppongi Hills Tokyo City View");
+    expect(result.kind).toBe("unique");
+  });
+
+  it("still matches exact hyphenated name", async () => {
+    const { resolvePlaceRef } = await import("../../src/resolvers/place-ref.ts");
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "dayPlan",
+            heading: "",
+            date: "2026-06-01",
+            blocks: [
+              {
+                id: 1,
+                type: "place",
+                place: {
+                  name: "Roppongi Hills - Tokyo City View",
+                  place_id: "ChIJabc",
+                  geometry: { location: { lat: 35.66, lng: 139.73 } },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const result = resolvePlaceRef(trip, "Roppongi Hills - Tokyo City View");
+    expect(result.kind).toBe("unique");
+  });
+});

--- a/tests/unit/remove-note.test.ts
+++ b/tests/unit/remove-note.test.ts
@@ -66,6 +66,40 @@ describe("extractPlainText", () => {
     );
   });
 
+  it("skips embed ops (non-string inserts)", () => {
+    const block = {
+      id: 1,
+      type: "note" as const,
+      text: {
+        ops: [
+          { insert: "Before " },
+          { insert: { image: "https://example.com/img.jpg" } as unknown as string },
+          { insert: "after\n" },
+        ],
+      },
+    };
+    expect(extractPlainText(block)).toBe("Before after\n");
+  });
+
+  it("handles unicode checkbox characters and brackets", () => {
+    const block = {
+      id: 1,
+      type: "note" as const,
+      text: {
+        ops: [
+          { insert: "☑ Pre-departure checklist\n" },
+          { insert: "[ ] Book Pokemon Cafe Tokyo\n" },
+          { insert: "[ ] opens 31 days ahead, sells out in minutes\n" },
+        ],
+      },
+    };
+    const text = extractPlainText(block);
+    expect(text).toContain("☑");
+    expect(text.toLowerCase()).toContain("pre-departure checklist");
+    expect(text.toLowerCase()).toContain("book pokemon cafe tokyo");
+    expect(text.toLowerCase()).toContain("opens 31 days ahead");
+  });
+
   it("returns empty string for missing text", () => {
     expect(extractPlainText({ id: 1, type: "note" as const })).toBe("");
   });
@@ -141,6 +175,39 @@ describe("findNoteMatches", () => {
     };
     const result = findNoteMatches(trip, "book");
     expect(result).toHaveLength(2);
+  });
+
+  it("finds notes with unicode checkboxes via substring match", () => {
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "dayPlan",
+            heading: "",
+            date: "2026-06-01",
+            blocks: [
+              {
+                id: 99,
+                type: "note",
+                text: {
+                  ops: [
+                    { insert: "☑ Pre-departure checklist\n" },
+                    { insert: "[ ] Book Pokemon Cafe Tokyo\n" },
+                    { insert: "[ ] opens 31 days ahead, sells out in minutes\n" },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    };
+    expect(findNoteMatches(trip, "Pre-departure checklist")).toHaveLength(1);
+    expect(findNoteMatches(trip, "Book Pokemon Cafe Tokyo")).toHaveLength(1);
+    expect(findNoteMatches(trip, "opens 31 days ahead, sells out in minutes")).toHaveLength(1);
   });
 
   it("ignores non-note blocks", () => {

--- a/tests/unit/remove-note.test.ts
+++ b/tests/unit/remove-note.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import type { Json0Op } from "../../src/ot/apply.ts";
+import type { TripPlan } from "../../src/types.ts";
+import {
+  extractPlainText,
+  findNoteMatches,
+  removeNote,
+} from "../../src/tools/remove-note.ts";
+import { checklistTrip } from "../fixtures/checklist-trip.ts";
+import { mixedBlocksTrip } from "../fixtures/mixed-blocks-trip.ts";
+
+function fresh(trip: TripPlan): TripPlan {
+  return structuredClone(trip);
+}
+
+function makeFakeContext(trip: TripPlan): {
+  ctx: AppContext;
+  submittedOps: Json0Op[][];
+  invalidateCount: { value: number };
+} {
+  const submittedOps: Json0Op[][] = [];
+  const invalidateCount = { value: 0 };
+
+  const ctx = {
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      get: async () => structuredClone(trip),
+      applyLocalOp: () => {},
+      invalidate: () => {
+        invalidateCount.value++;
+      },
+    },
+  } as unknown as AppContext;
+
+  return { ctx, submittedOps, invalidateCount };
+}
+
+// ---------------------------------------------------------------------------
+// extractPlainText
+// ---------------------------------------------------------------------------
+
+describe("extractPlainText", () => {
+  it("joins all insert strings from delta ops", () => {
+    const block = {
+      id: 1,
+      type: "note" as const,
+      text: {
+        ops: [
+          { insert: "Check out the " },
+          { insert: "Nakamise shopping street", attributes: { link: "https://example.com" } },
+          { insert: " before heading to the temple.\n" },
+        ],
+      },
+    };
+    expect(extractPlainText(block)).toBe(
+      "Check out the Nakamise shopping street before heading to the temple.\n",
+    );
+  });
+
+  it("returns empty string for missing text", () => {
+    expect(extractPlainText({ id: 1, type: "note" as const })).toBe("");
+  });
+
+  it("returns empty string for empty ops array", () => {
+    expect(extractPlainText({ id: 1, type: "note" as const, text: { ops: [] } })).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findNoteMatches
+// ---------------------------------------------------------------------------
+
+describe("findNoteMatches", () => {
+  it("returns empty array when no notes match", () => {
+    const trip = fresh(checklistTrip);
+    const result = findNoteMatches(trip, "xyz_impossible_match");
+    expect(result).toHaveLength(0);
+  });
+
+  it("finds a matching note case-insensitively", () => {
+    const trip = fresh(checklistTrip);
+    const result = findNoteMatches(trip, "SUNSCREEN");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.plainText).toContain("sunscreen");
+  });
+
+  it("finds notes with multi-op rich-text deltas (mixed-blocks fixture)", () => {
+    const trip = fresh(mixedBlocksTrip);
+    const result = findNoteMatches(trip, "nakamise");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.plainText).toContain("Nakamise");
+  });
+
+  it("returns correct sectionIndex and blockIndex", () => {
+    const trip = fresh(checklistTrip);
+    const result = findNoteMatches(trip, "sunscreen");
+    expect(result).toHaveLength(1);
+    const { sectionIndex, blockIndex } = result[0]!;
+    const section = trip.itinerary.sections[sectionIndex]!;
+    const block = section.blocks[blockIndex]!;
+    expect(block.type).toBe("note");
+  });
+
+  it("filters by day when day is specified", () => {
+    const trip = fresh(checklistTrip);
+    // The sunscreen note is on 2026-06-01 (day 1)
+    const onDay1 = findNoteMatches(trip, "sunscreen", "day 1");
+    expect(onDay1).toHaveLength(1);
+
+    const onDay2 = findNoteMatches(trip, "sunscreen", "day 2");
+    expect(onDay2).toHaveLength(0);
+  });
+
+  it("returns multiple matches when substring is broad", () => {
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "placeList",
+            heading: "Places to visit",
+            date: null,
+            blocks: [
+              { id: 10, type: "note", text: { ops: [{ insert: "Book the restaurant early\n" }] } },
+              { id: 11, type: "note", text: { ops: [{ insert: "Book tickets online\n" }] } },
+            ],
+          },
+        ],
+      },
+    };
+    const result = findNoteMatches(trip, "book");
+    expect(result).toHaveLength(2);
+  });
+
+  it("ignores non-note blocks", () => {
+    const trip = fresh(checklistTrip);
+    // "Park" is a place name, not a note — should not match
+    const result = findNoteMatches(trip, "Park Güell");
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeNote handler
+// ---------------------------------------------------------------------------
+
+describe("removeNote", () => {
+  it("returns not-found error when no notes match", async () => {
+    const { ctx } = makeFakeContext(checklistTrip);
+    const result = await removeNote(ctx, {
+      trip_key: "checklisttripkey",
+      text: "xyz_no_match_at_all",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+  });
+
+  it("removes the matching note and returns confirmation", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await removeNote(ctx, {
+      trip_key: "checklisttripkey",
+      text: "sunscreen",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("Removed note");
+    expect(result.content[0]!.text).toContain("sunscreen");
+    expect(submittedOps).toHaveLength(1);
+    // The op must be an ld (list delete) — never expose raw paths in the response
+    const op = submittedOps[0]![0] as { p: unknown[]; ld: unknown };
+    expect(op.ld).toBeDefined();
+    expect((op.ld as { type: string }).type).toBe("note");
+  });
+
+  it("returns ambiguous list when multiple notes match", async () => {
+    const trip: TripPlan = {
+      ...fresh(checklistTrip),
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "placeList",
+            heading: "Places to visit",
+            date: null,
+            blocks: [
+              { id: 10, type: "note", text: { ops: [{ insert: "Book the restaurant early\n" }] } },
+              { id: 11, type: "note", text: { ops: [{ insert: "Book tickets online\n" }] } },
+            ],
+          },
+        ],
+      },
+    };
+    const { ctx, submittedOps } = makeFakeContext(trip);
+    const result = await removeNote(ctx, { trip_key: "checklisttripkey", text: "book" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("matches 2 notes");
+    expect(result.content[0]!.text).toContain("Book the restaurant");
+    expect(result.content[0]!.text).toContain("Book tickets");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("respects day filter in handler", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    // sunscreen note is on day 1 — filtering by day 2 should give not-found
+    const result = await removeNote(ctx, {
+      trip_key: "checklisttripkey",
+      text: "sunscreen",
+      day: "day 2",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+    expect(submittedOps).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Three changes that close the gap between the MCP and real trip editing workflows:

### 1. `wanderlog_remove_note` (originally reviewed)
- Case-insensitive substring matching across note blocks
- Zero/one/many disambiguation: single match deletes, multiple returns previews
- Optional day filter
- 14 unit tests

### 2. `wanderlog_edit_note` (new)
- Find-and-replace across freestanding notes, place annotations, and checklist titles/items
- Rich-text delta aware: replaces within a single op, refuses to cross formatting boundaries
- Plain-string checklist title editing via `oi`/`od`
- Same zero/one/many disambiguation pattern as `remove_note`
- 21 unit tests

### 3. Bug fixes (new)
- `extractDeltaText` now skips embed objects (prevents `[object Object]` pollution in plain-text output)
- `resolvePlaceRef` now normalizes hyphens/em-dashes alongside whitespace: "Roppongi Hills - Tokyo City View" now matches "Roppongi Hills Tokyo City View"

## Test results

- `npm run test`: **238 pass** (was 214)
- Build: clean
- Integration tests: require `.env` cookie (not available in CI)

## Files changed

- `src/tools/remove-note.ts` — embed fix + shared `extractDeltaText` export
- `src/tools/edit-note.ts` — new tool
- `src/resolvers/place-ref.ts` — punctuation normalization
- `src/server.ts` — tool registration
- `tests/unit/remove-note.test.ts` — +6 tests
- `tests/unit/edit-note.test.ts` — new, 21 tests