### PR TITLE
feat: add wanderlog_search_guides and wanderlog_get_guide tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ The agent calls the tools, interleaves places and notes for each day, adds hotel
 
 **See a real example:** [14-day Japan Golden Route](https://wanderlog.com/view/dmvegdhqsa/japan-golden-route--tokyo--hakone--kyoto--nara--osaka) — built entirely by an AI agent using this MCP server.
 
+## What's New (Unreleased)
+
+- `wanderlog_search_guides` + `wanderlog_get_guide` — discover and read user-written Wanderlog travel guides. The LLM can ask "what guides exist for Vietnam?" and pull full itineraries to use as inspiration.
+
 ## What's New in v0.2.0
 
 - `wanderlog_rename_day` — replace auto-generated day headings (e.g. `"Barcelona"`) with descriptive ones (`"Arrival — Feria de Abril"`). Pass `""` to reset back to the default.
@@ -69,6 +73,8 @@ and a ryokan in Shinjuku."
 | `wanderlog_get_trip` | View a full itinerary, or filter to a single day |
 | `wanderlog_get_trip_url` | Get a shareable wanderlog.com link |
 | `wanderlog_search_places` | Find real-world places near a trip's destination |
+| `wanderlog_search_guides` | List user-written travel guides for a destination, with fallback suggestions when none exist |
+| `wanderlog_get_guide` | Read the full content of a public Wanderlog guide (sections, places, notes) |
 | `wanderlog_create_trip` | Create a new trip with destination + date range |
 | `wanderlog_add_place` | Add a place to a specific day or general list |
 | `wanderlog_add_note` | Add a note (transit tips, booking info, local advice) |

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -75,7 +75,14 @@ export class WanderlogNotFoundError extends WanderlogError {
                 "Retry this tool with a more specific place name (include the city or neighborhood).",
               ],
             }
-          : {};
+          : res === "guide"
+            ? {
+                hint: "Use wanderlog_search_guides to find a valid guide_key for a destination.",
+                followUps: [
+                  "Call wanderlog_search_guides with a destination to discover available guides.",
+                ],
+              }
+            : {};
     super(`${resource}${id} not found`, "not_found", options);
     this.name = "WanderlogNotFoundError";
   }

--- a/src/formatters/trip-summary.ts
+++ b/src/formatters/trip-summary.ts
@@ -67,15 +67,22 @@ function renderSection(section: Section, format: ResponseFormat): string | null 
   if (section.mode === "dayPlan" && section.date) {
     return renderDaySection(section, format);
   }
-  if (!section.blocks || section.blocks.length === 0) return null;
+
+  const sectionText = section.text ? quillToPlain(section.text).trim() : "";
+  const blockLines = (section.blocks ?? [])
+    .map((b) => formatBlockLine(b, format))
+    .filter(Boolean) as string[];
+
+  if (!sectionText && blockLines.length === 0) return null;
 
   const icon = sectionIcon(section);
   const heading = section.heading?.trim() || sectionDefaultHeading(section);
-  const lines = section.blocks
-    .map((b) => formatBlockLine(b, format))
-    .filter(Boolean) as string[];
-  if (lines.length === 0) return null;
-  return `${icon} ${heading}\n${lines.map((l) => `  • ${l}`).join("\n")}`;
+  const parts = [`${icon} ${heading}`];
+  if (sectionText) parts.push(sectionText);
+  if (blockLines.length > 0) {
+    parts.push(blockLines.map((l) => `  • ${l}`).join("\n"));
+  }
+  return parts.join("\n");
 }
 
 function renderDaySection(section: Section, format: ResponseFormat): string {

--- a/src/formatters/trip-summary.ts
+++ b/src/formatters/trip-summary.ts
@@ -161,7 +161,7 @@ export function formatBlockLine(block: Block, format: ResponseFormat): string | 
       case "place":
         return formatPlaceBlock(block as PlaceBlock, format);
       case "note":
-        return formatNoteBlock(block as NoteBlock);
+        return formatNoteBlock(block as NoteBlock, format);
       case "checklist":
         return formatChecklistBlock(block as ChecklistBlock, format);
       case "flight":
@@ -208,18 +208,20 @@ function formatPlaceBlock(block: PlaceBlock, format: ResponseFormat): string | n
   if (block.hotel?.confirmationNumber)
     parts.push(`conf. ${block.hotel.confirmationNumber}`);
   if (hasNote) {
-    const truncated = inlineNote.length > 200 ? `${inlineNote.slice(0, 197)}…` : inlineNote;
-    parts.push(`📝 ${truncated}`);
+    parts.push(`📝 ${inlineNote}`);
   }
   return parts.join(" · ");
 }
 
-function formatNoteBlock(block: NoteBlock): string | null {
+function formatNoteBlock(block: NoteBlock, format: ResponseFormat): string | null {
   const text = quillToPlain(block.text);
   if (!text) return null;
   const oneLine = text.replace(/\s+/g, " ").trim();
-  const truncated = oneLine.length > 200 ? `${oneLine.slice(0, 197)}…` : oneLine;
-  return `📝 ${truncated}`;
+  if (format === "concise") {
+    const truncated = oneLine.length > 200 ? `${oneLine.slice(0, 197)}…` : oneLine;
+    return `📝 ${truncated}`;
+  }
+  return `📝 ${oneLine}`;
 }
 
 function formatChecklistBlock(block: ChecklistBlock, format: ResponseFormat): string | null {

--- a/src/server.ts
+++ b/src/server.ts
@@ -80,6 +80,16 @@ import {
   removeNoteDescription,
   removeNoteInputSchema,
 } from "./tools/remove-note.js";
+import {
+  searchGuides,
+  searchGuidesDescription,
+  searchGuidesInputSchema,
+} from "./tools/search-guides.js";
+import {
+  getGuide,
+  getGuideDescription,
+  getGuideInputSchema,
+} from "./tools/get-guide.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -121,6 +131,11 @@ of places. A complete itinerary uses these building blocks:
   5. wanderlog_add_expense — add estimated costs for meals, entrance fees, transport passes.
      Link each expense to its place for budget tracking.
   6. wanderlog_annotate_place — update an existing place with a note, start/end time, or both.
+  7. wanderlog_search_guides + wanderlog_get_guide — when the user wants inspiration ("give
+     me an itinerary I can copy", "what guides exist for Vietnam"), call search_guides FIRST
+     to list curated user-written guides for the destination, then get_guide with the chosen
+     guide_key to read the full content. Use this for OTHER people's published guides; for
+     your own trips use wanderlog_get_trip.
 
 Example add_place call with all features:
   wanderlog_add_place(trip_key, place: "Sensō-ji", day: "day 1",
@@ -175,6 +190,30 @@ export function buildServer(ctx: AppContext): McpServer {
       inputSchema: searchPlacesInputSchema,
     },
     requireAuth(ctx, async (args) => searchPlaces(ctx, args as Parameters<typeof searchPlaces>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_search_guides",
+    {
+      title: "Search Wanderlog travel guides",
+      description: searchGuidesDescription,
+      inputSchema: searchGuidesInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      searchGuides(ctx, args as Parameters<typeof searchGuides>[1]),
+    ),
+  );
+
+  server.registerTool(
+    "wanderlog_get_guide",
+    {
+      title: "Read a Wanderlog travel guide",
+      description: getGuideDescription,
+      inputSchema: getGuideInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      getGuide(ctx, args as Parameters<typeof getGuide>[1]),
+    ),
   );
 
   server.registerTool(

--- a/src/tools/get-guide.ts
+++ b/src/tools/get-guide.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogValidationError } from "../errors.js";
+import { formatTrip } from "../formatters/trip-summary.js";
+import { resolveDay } from "../resolvers/day.js";
+
+export const getGuideInputSchema = {
+  guide_key: z
+    .string()
+    .min(1)
+    .describe(
+      "Guide's viewKey (the 'guide_key' returned by wanderlog_search_guides, e.g. 'hejurejdks').",
+    ),
+  day: z
+    .string()
+    .optional()
+    .describe(
+      "Optional day filter — pass a day heading or date to scope the output to one day.",
+    ),
+  response_format: z
+    .enum(["concise", "detailed"])
+    .default("concise")
+    .describe(
+      "Output verbosity. 'concise' is a readable summary; 'detailed' adds addresses, phone numbers, ratings.",
+    ),
+};
+
+export const getGuideDescription = `
+Fetches the full content of a public Wanderlog guide — sections, places, and notes — and
+renders it as readable text. Pass the guide_key from a wanderlog_search_guides response.
+
+For your own trips, use wanderlog_get_trip instead.
+`.trim();
+
+export type GetGuideArgs = {
+  guide_key: string;
+  day?: string;
+  response_format?: "concise" | "detailed";
+};
+
+export async function getGuide(
+  ctx: AppContext,
+  args: GetGuideArgs,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    if (!args.guide_key || args.guide_key.trim().length === 0) {
+      throw new WanderlogValidationError("guide_key is required");
+    }
+    const trip = await ctx.rest.getGuideContent(args.guide_key);
+    const day = args.day ? resolveDay(trip, args.day) : undefined;
+    const text = formatTrip(trip, args.response_format ?? "concise", day);
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const e =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: e }], isError: true };
+  }
+}

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -174,8 +174,45 @@ export function geoRef(g: GeoWithGoodGuides): GuideGeoRef {
 }
 
 export async function searchGuides(
-  _ctx: AppContext,
-  _args: SearchGuidesArgs,
+  ctx: AppContext,
+  args: SearchGuidesArgs,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
-  throw new WanderlogError("Not implemented", "not_implemented");
+  try {
+    const norm = validateArgs(args);
+    const { geo: resolved, alternative_geos } = await resolveGeo(ctx, norm);
+    const good = await loadGoodGuides(ctx);
+    const match = good.find((g) => g.id === resolved.geo_id);
+
+    if (!match) {
+      const top5 = [...good]
+        .sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0))
+        .slice(0, 5)
+        .map(geoRef);
+      const body = {
+        kind: "no_guides" as const,
+        resolved_geo: resolved,
+        alternative_geos_with_guides: top5,
+      };
+      return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
+    }
+
+    const { guides } = await ctx.rest.getGuidesForGeo(match.id);
+    const projected = guides.map((g) => projectGuide(g, norm.response_format));
+
+    const body = {
+      kind: "guides" as const,
+      geo: geoRef(match),
+      alternative_geos,
+      returned: projected.length,
+      total: projected.length,
+      guides: projected,
+    };
+    return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
+  } catch (err) {
+    const e =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: e }], isError: true };
+  }
 }

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -157,13 +157,15 @@ export function projectGuide(
     like_count: g.likeCount ?? null,
     blurb: g.authorBlurb ?? null,
     url: `https://wanderlog.com/view/${g.key}`,
+    edited_at: g.editedAt ?? null,
+    start_date: g.startDate ?? null,
+    end_date: g.endDate ?? null,
   };
   if (format === "concise") return base;
   return {
     ...base,
     author_name: g.user.name,
     profile_picture_url: imageUrl(g.user.profilePictureKey),
-    edited_at: g.editedAt ?? null,
     distinction: g.distinction ?? null,
     header_image_url: imageUrl(g.headerImageKey),
   };

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -73,12 +73,25 @@ export async function resolveGeo(
   args: Pick<SearchGuidesArgs, "destination" | "geo_id">,
 ): Promise<{ geo: GuideGeoRef; alternative_geos: GuideGeoRef[] }> {
   if (args.geo_id !== undefined) {
-    const g = await ctx.rest.getGeo(args.geo_id);
+    const good = await loadGoodGuides(ctx);
+    const match = good.find((g) => g.id === args.geo_id);
+    if (!match) {
+      throw new WanderlogError(
+        `Geo ${args.geo_id} not found in guides list`,
+        "geo_not_found",
+        {
+          hint: "Use a destination name or a geo_id from a prior search result.",
+          followUps: [
+            "Retry wanderlog_search_guides with a valid destination name.",
+          ],
+        },
+      );
+    }
     return {
       geo: {
-        geo_id: g.id,
-        name: g.name,
-        country: g.countryName ?? null,
+        geo_id: match.id,
+        name: match.name,
+        country: match.countryName ?? null,
         subcategory: null,
       },
       alternative_geos: [],

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -4,10 +4,12 @@ import type {
   GeoWithGoodGuides,
   GuideGeoRef,
   GuideSummary,
+  GuidesForGeoResponse,
   WanderlogGuide,
 } from "../types.js";
 import {
   WanderlogError,
+  WanderlogNotFoundError,
   WanderlogValidationError,
 } from "../errors.js";
 
@@ -73,25 +75,14 @@ export async function resolveGeo(
   args: Pick<SearchGuidesArgs, "destination" | "geo_id">,
 ): Promise<{ geo: GuideGeoRef; alternative_geos: GuideGeoRef[] }> {
   if (args.geo_id !== undefined) {
-    const good = await loadGoodGuides(ctx);
-    const match = good.find((g) => g.id === args.geo_id);
-    if (!match) {
-      throw new WanderlogError(
-        "The provided geo_id is not in the curated guides list",
-        "geo_not_found",
-        {
-          hint: "Use a destination name, or pass a geo_id from a prior wanderlog_search_guides response's 'alternative_geos_with_guides'.",
-          followUps: [
-            "Retry wanderlog_search_guides with a destination name (e.g. 'Vietnam', 'Kyoto').",
-          ],
-        },
-      );
-    }
+    // Trust the caller's geo_id. The canonical name/country/subcategory will
+    // be filled in by getGuidesForGeo's embedded geo (or left as a stub if
+    // the geo has no guides at all).
     return {
       geo: {
-        geo_id: match.id,
-        name: match.name,
-        country: match.countryName ?? null,
+        geo_id: args.geo_id,
+        name: "",
+        country: null,
         subcategory: null,
       },
       alternative_geos: [],
@@ -192,29 +183,36 @@ export async function searchGuides(
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
     const norm = validateArgs(args);
-    const { geo: resolved, alternative_geos } = await resolveGeo(ctx, norm);
-    const good = await loadGoodGuides(ctx);
-    const match = good.find((g) => g.id === resolved.geo_id);
+    const { geo: stub, alternative_geos } = await resolveGeo(ctx, norm);
 
-    if (!match) {
+    let guidesResp: GuidesForGeoResponse | null = null;
+    try {
+      guidesResp = await ctx.rest.getGuidesForGeo(stub.geo_id);
+    } catch (err) {
+      if (!(err instanceof WanderlogNotFoundError)) throw err;
+    }
+
+    if (!guidesResp || guidesResp.guides.length === 0) {
+      const good = await loadGoodGuides(ctx);
       const top5 = [...good]
         .sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0))
         .slice(0, 5)
         .map(geoRef);
+      const resolved_geo: GuideGeoRef = guidesResp?.geo ? geoRef(guidesResp.geo) : stub;
       const body = {
         kind: "no_guides" as const,
-        resolved_geo: resolved,
+        resolved_geo,
         alternative_geos_with_guides: top5,
       };
       return { content: [{ type: "text", text: JSON.stringify(body, null, 2) }] };
     }
 
-    const { guides } = await ctx.rest.getGuidesForGeo(match.id);
-    const projected = guides.map((g) => projectGuide(g, norm.response_format));
-
+    const projected = guidesResp.guides.map((g) =>
+      projectGuide(g, norm.response_format),
+    );
     const body = {
       kind: "guides" as const,
-      geo: geoRef(match),
+      geo: geoRef(guidesResp.geo),
       alternative_geos,
       returned: projected.length,
       total: projected.length,

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { AppContext } from "../context.js";
+import type { GuideGeoRef } from "../types.js";
 import {
   WanderlogError,
   WanderlogValidationError,
@@ -60,6 +61,56 @@ export function validateArgs(args: SearchGuidesArgs): SearchGuidesArgs & {
     );
   }
   return { ...args, response_format: args.response_format ?? "concise" };
+}
+
+export async function resolveGeo(
+  ctx: AppContext,
+  args: Pick<SearchGuidesArgs, "destination" | "geo_id">,
+): Promise<{ geo: GuideGeoRef; alternative_geos: GuideGeoRef[] }> {
+  if (args.geo_id !== undefined) {
+    const g = await ctx.rest.getGeo(args.geo_id);
+    return {
+      geo: {
+        geo_id: g.id,
+        name: g.name,
+        country: g.countryName ?? null,
+        subcategory: null,
+      },
+      alternative_geos: [],
+    };
+  }
+  const candidates = await ctx.rest.geoAutocomplete(args.destination!);
+  if (candidates.length === 0) {
+    throw new WanderlogError(
+      `No geo found matching "${args.destination}"`,
+      "destination_not_found",
+      {
+        hint: "Try a more specific name (include the country) or pass an explicit geo_id from a prior search.",
+        followUps: [
+          "Retry wanderlog_search_guides with a more specific destination (include the country or region).",
+        ],
+      },
+    );
+  }
+  const ranked = [...candidates].sort(
+    (a, b) => (b.popularity ?? 0) - (a.popularity ?? 0),
+  );
+  const top = ranked[0]!;
+  const alternatives = ranked.slice(1, 3).map((c) => ({
+    geo_id: c.id,
+    name: c.name,
+    country: c.countryName ?? null,
+    subcategory: null,
+  }));
+  return {
+    geo: {
+      geo_id: top.id,
+      name: top.name,
+      country: top.countryName ?? null,
+      subcategory: null,
+    },
+    alternative_geos: alternatives,
+  };
 }
 
 export async function searchGuides(

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -158,8 +158,6 @@ export function projectGuide(
     blurb: g.authorBlurb ?? null,
     url: `https://wanderlog.com/view/${g.key}`,
     edited_at: g.editedAt ?? null,
-    start_date: g.startDate ?? null,
-    end_date: g.endDate ?? null,
   };
   if (format === "concise") return base;
   return {

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -77,12 +77,12 @@ export async function resolveGeo(
     const match = good.find((g) => g.id === args.geo_id);
     if (!match) {
       throw new WanderlogError(
-        `Geo ${args.geo_id} not found in guides list`,
+        "The provided geo_id is not in the curated guides list",
         "geo_not_found",
         {
-          hint: "Use a destination name or a geo_id from a prior search result.",
+          hint: "Use a destination name, or pass a geo_id from a prior wanderlog_search_guides response's 'alternative_geos_with_guides'.",
           followUps: [
-            "Retry wanderlog_search_guides with a valid destination name.",
+            "Retry wanderlog_search_guides with a destination name (e.g. 'Vietnam', 'Kyoto').",
           ],
         },
       );

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import {
+  WanderlogError,
+  WanderlogValidationError,
+} from "../errors.js";
+
+export const searchGuidesInputSchema = {
+  destination: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Free-text destination (e.g. 'Vietnam', 'Kyoto'). Resolved via geoAutocomplete; multi-match auto-picks the highest-popularity geo and surfaces up to 2 candidates in 'alternative_geos'.",
+    ),
+  geo_id: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe(
+      "Explicit Wanderlog geo id (from a prior response's 'geo' or 'alternative_geos').",
+    ),
+  response_format: z
+    .enum(["concise", "detailed"])
+    .default("concise")
+    .describe(
+      "Output verbosity. 'concise' (default) returns guide_key, title, author, place_count, view_count. 'detailed' adds blurb, like_count, edited_at, distinction, profile_picture_url, header_image_url.",
+    ),
+};
+
+export const searchGuidesDescription = `
+Lists user-written Wanderlog travel guides for a destination — long-form recommendations and
+itineraries other travellers have published. Use this when the user asks for inspiration, an
+itinerary they can copy, or "what guides exist for X".
+
+Specify exactly one of destination or geo_id. For free-text destinations the highest-popularity
+match is picked; up to 2 candidates appear in 'alternative_geos' as a soft hint. When the
+destination has no curated guides yet, the response carries 'alternative_geos_with_guides'
+with the top 5 nearby destinations that do.
+
+Pass the returned guide_key to wanderlog_get_guide to read the full content of one guide.
+`.trim();
+
+export type SearchGuidesArgs = {
+  destination?: string;
+  geo_id?: number;
+  response_format?: "concise" | "detailed";
+};
+
+export function validateArgs(args: SearchGuidesArgs): SearchGuidesArgs & {
+  response_format: "concise" | "detailed";
+} {
+  const modesSet = [args.destination !== undefined, args.geo_id !== undefined].filter(
+    Boolean,
+  ).length;
+  if (modesSet !== 1) {
+    throw new WanderlogValidationError(
+      "Pass exactly one of destination or geo_id.",
+    );
+  }
+  return { ...args, response_format: args.response_format ?? "concise" };
+}
+
+export async function searchGuides(
+  _ctx: AppContext,
+  _args: SearchGuidesArgs,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  throw new WanderlogError("Not implemented", "not_implemented");
+}

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { AppContext } from "../context.js";
-import type { GuideGeoRef } from "../types.js";
+import type {
+  GeoWithGoodGuides,
+  GuideGeoRef,
+  GuideSummary,
+  WanderlogGuide,
+} from "../types.js";
 import {
   WanderlogError,
   WanderlogValidationError,
@@ -110,6 +115,61 @@ export async function resolveGeo(
       subcategory: null,
     },
     alternative_geos: alternatives,
+  };
+}
+
+const IMAGE_BASE = "https://wanderlog.com/image/upload";
+
+let cachedGoodGuides: Promise<GeoWithGoodGuides[]> | null = null;
+
+export function __resetCacheForTests(): void {
+  cachedGoodGuides = null;
+}
+
+export function loadGoodGuides(ctx: AppContext): Promise<GeoWithGoodGuides[]> {
+  if (!cachedGoodGuides) {
+    cachedGoodGuides = ctx.rest.listGoodGuides().catch((err) => {
+      cachedGoodGuides = null;
+      throw err;
+    });
+  }
+  return cachedGoodGuides;
+}
+
+function imageUrl(key: string | null | undefined): string | null {
+  return key ? `${IMAGE_BASE}/${key}` : null;
+}
+
+export function projectGuide(
+  g: WanderlogGuide,
+  format: "concise" | "detailed",
+): GuideSummary {
+  const base: GuideSummary = {
+    guide_key: g.key,
+    title: g.title,
+    author: g.user.username,
+    place_count: g.placeCount ?? null,
+    view_count: g.viewCount ?? null,
+  };
+  if (format === "concise") return base;
+  return {
+    ...base,
+    author_name: g.user.name,
+    profile_picture_url: imageUrl(g.user.profilePictureKey),
+    blurb: g.authorBlurb ?? null,
+    like_count: g.likeCount ?? null,
+    edited_at: g.editedAt ?? null,
+    distinction: g.distinction ?? null,
+    header_image_url: imageUrl(g.headerImageKey),
+  };
+}
+
+export function geoRef(g: GeoWithGoodGuides): GuideGeoRef {
+  return {
+    geo_id: g.id,
+    name: g.name,
+    country: g.countryName ?? null,
+    subcategory: g.subcategory ?? null,
   };
 }
 

--- a/src/tools/search-guides.ts
+++ b/src/tools/search-guides.ts
@@ -154,14 +154,15 @@ export function projectGuide(
     author: g.user.username,
     place_count: g.placeCount ?? null,
     view_count: g.viewCount ?? null,
+    like_count: g.likeCount ?? null,
+    blurb: g.authorBlurb ?? null,
+    url: `https://wanderlog.com/view/${g.key}`,
   };
   if (format === "concise") return base;
   return {
     ...base,
     author_name: g.user.name,
     profile_picture_url: imageUrl(g.user.profilePictureKey),
-    blurb: g.authorBlurb ?? null,
-    like_count: g.likeCount ?? null,
     edited_at: g.editedAt ?? null,
     distinction: g.distinction ?? null,
     header_image_url: imageUrl(g.headerImageKey),

--- a/src/transport/rest.ts
+++ b/src/transport/rest.ts
@@ -7,6 +7,8 @@ import {
 } from "../errors.js";
 import type {
   Geo,
+  GeoWithGoodGuides,
+  GuidesForGeoResponse,
   PlaceData,
   PlaceSuggestion,
   TripPlan,
@@ -174,6 +176,46 @@ export class RestClient {
       `/api/geo/autocomplete/${encodeURIComponent(query)}`,
     );
     return env.data ?? [];
+  }
+
+  async listGoodGuides(): Promise<GeoWithGoodGuides[]> {
+    const env = await this.request<Envelope<{ data?: GeoWithGoodGuides[] }>>(
+      "GET",
+      "/api/geo/geosWithGoodGuides",
+    );
+    return env.data ?? [];
+  }
+
+  async getGuidesForGeo(geoId: number): Promise<GuidesForGeoResponse> {
+    const env = await this.request<
+      Envelope<{ data?: { geoWithGoodGuides?: GuidesForGeoResponse } }>
+    >(
+      "GET",
+      `/api/tripPlans/browse/guides/${encodeURIComponent(String(geoId))}`,
+    );
+    const data = env.data?.geoWithGoodGuides;
+    if (!data) {
+      throw new WanderlogNotFoundError("Guides", String(geoId));
+    }
+    return data;
+  }
+
+  async getGuideContent(viewKey: string): Promise<TripPlan> {
+    try {
+      const env = await this.request<Envelope<{ tripPlan?: TripPlan }>>(
+        "GET",
+        `/api/tripPlans/${encodeURIComponent(viewKey)}?clientSchemaVersion=2`,
+      );
+      if (!env.tripPlan) {
+        throw new WanderlogNotFoundError("Guide", viewKey);
+      }
+      return env.tripPlan;
+    } catch (err) {
+      if (err instanceof WanderlogNotFoundError) {
+        throw new WanderlogNotFoundError("Guide", viewKey);
+      }
+      throw err;
+    }
   }
 
   async createTrip(args: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -301,9 +301,11 @@ export type GuideSummary = {
   like_count: number | null;
   blurb: string | null;
   url: string;
+  edited_at: string | null;
+  start_date: string | null;
+  end_date: string | null;
   author_name?: string;
   profile_picture_url?: string | null;
-  edited_at?: string | null;
   distinction?: string | null;
   header_image_url?: string | null;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -302,8 +302,6 @@ export type GuideSummary = {
   blurb: string | null;
   url: string;
   edited_at: string | null;
-  start_date: string | null;
-  end_date: string | null;
   author_name?: string;
   profile_picture_url?: string | null;
   distinction?: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export type Section = {
   heading: string;
   date: string | null;
   blocks: Block[];
+  text?: QuillDelta;
   placeMarkerColor?: string;
   placeMarkerIcon?: string;
 };
@@ -297,10 +298,11 @@ export type GuideSummary = {
   author: string;
   place_count: number | null;
   view_count: number | null;
+  like_count: number | null;
+  blurb: string | null;
+  url: string;
   author_name?: string;
   profile_picture_url?: string | null;
-  blurb?: string | null;
-  like_count?: number | null;
   edited_at?: string | null;
   distinction?: string | null;
   header_image_url?: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,3 +223,102 @@ export type PlaceSuggestion = {
   };
   types?: string[];
 };
+
+export type GuideAuthor = {
+  id: number;
+  username: string;
+  name: string;
+  profilePictureKey?: string | null;
+  visitGeosCount?: number;
+  countriesCount?: number;
+  showProfileProBadge?: boolean;
+  isProUser?: boolean;
+};
+
+export type WanderlogGuide = {
+  id: number;
+  keyType: string;
+  key: string;
+  journalKey?: string;
+  type: string;
+  title: string;
+  user: GuideAuthor;
+  editedAt?: string;
+  isPrimary?: boolean;
+  placeCount?: number;
+  journalStopCount?: number;
+  openedAt?: string | null;
+  headerImageKey?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  viewCount?: number;
+  likeCount?: number;
+  commentCount?: number | null;
+  collaborators?: GuideAuthor[];
+  distinction?: string;
+  itemType?: string;
+  authorBlurb?: string;
+  isDraft?: boolean;
+  topImageKeys?: string[];
+  imageCount?: number | null;
+};
+
+export type GeoWithGoodGuides = {
+  id: number;
+  name: string;
+  stateName?: string | null;
+  countryName?: string | null;
+  depth?: number;
+  latitude?: number;
+  longitude?: number;
+  parentId?: number | null;
+  popularity?: number;
+  subcategory?: string;
+  bounds?: [number, number, number, number];
+  imageKey?: string | null;
+  countryCode?: string | null;
+};
+
+export type GuidesForGeoResponse = {
+  geo: GeoWithGoodGuides;
+  guides: WanderlogGuide[];
+};
+
+export type GuideGeoRef = {
+  geo_id: number;
+  name: string;
+  country: string | null;
+  subcategory: string | null;
+};
+
+export type GuideSummary = {
+  guide_key: string;
+  title: string;
+  author: string;
+  place_count: number | null;
+  view_count: number | null;
+  author_name?: string;
+  profile_picture_url?: string | null;
+  blurb?: string | null;
+  like_count?: number | null;
+  edited_at?: string | null;
+  distinction?: string | null;
+  header_image_url?: string | null;
+};
+
+export type GuideSearchSuccess = {
+  kind: "guides";
+  geo: GuideGeoRef;
+  alternative_geos: GuideGeoRef[];
+  returned: number;
+  total: number;
+  guides: GuideSummary[];
+};
+
+export type GuideSearchNoGuides = {
+  kind: "no_guides";
+  resolved_geo: GuideGeoRef;
+  alternative_geos_with_guides: GuideGeoRef[];
+};
+
+export type GuideSearchResult = GuideSearchSuccess | GuideSearchNoGuides;

--- a/tests/integration/guides.integration.test.ts
+++ b/tests/integration/guides.integration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { createContext } from "../../src/context.js";
+import { searchGuides } from "../../src/tools/search-guides.js";
+import { getGuide } from "../../src/tools/get-guide.js";
+
+const HAS_COOKIE = Boolean(process.env.WANDERLOG_COOKIE);
+
+describe.skipIf(!HAS_COOKIE)(
+  "wanderlog_search_guides + get_guide (integration)",
+  () => {
+    it(
+      "lists guides for New York City and reads the first one",
+      async () => {
+        const ctx = createContext();
+        const search = await searchGuides(ctx, { destination: "New York City" });
+        expect(search.isError).toBeUndefined();
+        const body = JSON.parse(search.content[0]!.text);
+        expect(body.kind).toBe("guides");
+        expect(body.guides.length).toBeGreaterThan(0);
+
+        const firstKey = body.guides[0].guide_key;
+        expect(typeof firstKey).toBe("string");
+        expect(firstKey.length).toBeGreaterThan(0);
+
+        const guide = await getGuide(ctx, { guide_key: firstKey });
+        expect(guide.isError).toBeUndefined();
+        expect(guide.content[0]!.text.length).toBeGreaterThan(50);
+      },
+      30_000,
+    );
+  },
+);

--- a/tests/integration/guides.integration.test.ts
+++ b/tests/integration/guides.integration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { createContext } from "../../src/context.js";
-import { searchGuides } from "../../src/tools/search-guides.js";
-import { getGuide } from "../../src/tools/get-guide.js";
+import { createContext } from "../../src/context.ts";
+import { searchGuides } from "../../src/tools/search-guides.ts";
+import { getGuide } from "../../src/tools/get-guide.ts";
 
 const HAS_COOKIE = Boolean(process.env.WANDERLOG_COOKIE);
 

--- a/tests/unit/errors.test.ts
+++ b/tests/unit/errors.test.ts
@@ -79,6 +79,13 @@ describe("WanderlogNotFoundError follow-ups", () => {
     expect(msg).toContain("Widget");
     expect(msg).not.toContain("Next steps:");
   });
+
+  it("Guide not-found suggests wanderlog_search_guides", () => {
+    const msg = new WanderlogNotFoundError("Guide", "abc123").toUserMessage();
+    expect(msg).toContain("wanderlog_search_guides");
+    expect(msg).toContain("abc123");
+    expect(msg).toContain("Next steps:");
+  });
 });
 
 describe("WanderlogNetworkError follow-ups", () => {

--- a/tests/unit/get-guide.test.ts
+++ b/tests/unit/get-guide.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import {
+  WanderlogError,
+  WanderlogNotFoundError,
+} from "../../src/errors.ts";
+import { getGuide } from "../../src/tools/get-guide.ts";
+import type { TripPlan } from "../../src/types.ts";
+
+function tripFixture(): TripPlan {
+  return {
+    key: "abc",
+    title: "Vietnam by Sea",
+    startDate: "2026-06-01",
+    endDate: "2026-06-10",
+    days: 10,
+    placeCount: 25,
+    itinerary: {
+      sections: [
+        {
+          heading: "About Vietnam",
+          text: { ops: [{ insert: "A long-form travel guide." }] },
+          blocks: [],
+        },
+      ],
+      budget: { amount: { amount: 0, currencyCode: "USD" }, expenses: [], payments: [], simplifyDebt: false },
+    },
+  } as unknown as TripPlan;
+}
+
+function ctxWith(getGuideContent: AppContext["rest"]["getGuideContent"]): AppContext {
+  return {
+    rest: { getGuideContent } as unknown as AppContext["rest"],
+  } as AppContext;
+}
+
+describe("getGuide", () => {
+  it("renders via formatTrip and returns text content", async () => {
+    const ctx = ctxWith(async () => tripFixture());
+    const res = await getGuide(ctx, { guide_key: "abc" });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toMatch(/Vietnam by Sea/);
+  });
+
+  it("rejects empty guide_key with a validation error", async () => {
+    const ctx = ctxWith(async () => tripFixture());
+    const res = await getGuide(ctx, { guide_key: "" });
+    expect(res.isError).toBe(true);
+  });
+
+  it("renders 'Guide not found' on 404", async () => {
+    const ctx = ctxWith(async () => {
+      throw new WanderlogNotFoundError("Guide", "missing");
+    });
+    const res = await getGuide(ctx, { guide_key: "missing" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/Guide.*not found/i);
+    expect(res.content[0]!.text).toMatch(/wanderlog_search_guides/);
+  });
+
+  it("surfaces unexpected errors with the 'Unexpected error' prefix", async () => {
+    const ctx = ctxWith(async () => {
+      throw new Error("network down");
+    });
+    const res = await getGuide(ctx, { guide_key: "abc" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toMatch(/Unexpected error.*network down/);
+  });
+});

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -113,7 +113,7 @@ describe("projectGuide", () => {
     headerImageKey: "yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW",
   };
 
-  it("concise projection keeps essentials, blurb, like_count, and a reference url", () => {
+  it("concise projection keeps essentials, blurb, like_count, url, and dates", () => {
     const p = projectGuide(raw, "concise");
     expect(p.guide_key).toBe("nlcviusycz");
     expect(p.title).toBe("Japan: Video Game Guide");
@@ -123,26 +123,44 @@ describe("projectGuide", () => {
     expect(p.like_count).toBe(2624);
     expect(p.blurb).toBe("I love Japan.");
     expect(p.url).toBe("https://wanderlog.com/view/nlcviusycz");
+    expect(p.edited_at).toBe("2026-05-03T02:05:37+00:00");
+    expect(p.start_date).toBeNull();
+    expect(p.end_date).toBeNull();
     // 'detailed' fields stay undefined in concise mode:
     expect(p.author_name).toBeUndefined();
     expect(p.profile_picture_url).toBeUndefined();
     expect(p.header_image_url).toBeUndefined();
     expect(p.distinction).toBeUndefined();
-    expect(p.edited_at).toBeUndefined();
   });
 
-  it("detailed projection adds author_name, edited_at, distinction, profile + header image URLs", () => {
+  it("detailed projection adds author_name, distinction, profile + header image URLs", () => {
     const p = projectGuide(raw, "detailed");
     // base fields still present
     expect(p.blurb).toBe("I love Japan.");
     expect(p.like_count).toBe(2624);
     expect(p.url).toBe("https://wanderlog.com/view/nlcviusycz");
+    expect(p.edited_at).toBe("2026-05-03T02:05:37+00:00");
     // detailed-only:
     expect(p.author_name).toBe("2e");
-    expect(p.edited_at).toBe("2026-05-03T02:05:37+00:00");
     expect(p.distinction).toBe("verified");
     expect(p.profile_picture_url).toMatch(/Vlp9auuKUEkRrlRR/);
     expect(p.header_image_url).toMatch(/yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW/);
+  });
+
+  it("surfaces start_date and end_date when guide has a travel-date range", () => {
+    const itinerary: WanderlogGuide = {
+      id: 99,
+      keyType: "view",
+      key: "xyz",
+      type: "recommendations",
+      title: "Two weeks in Japan",
+      user: { id: 1, username: "u", name: "U" },
+      startDate: "2024-04-01",
+      endDate: "2024-04-14",
+    };
+    const p = projectGuide(itinerary, "concise");
+    expect(p.start_date).toBe("2024-04-01");
+    expect(p.end_date).toBe("2024-04-14");
   });
 
   it("nulls and missing fields stay null/undefined gracefully", () => {
@@ -321,9 +339,12 @@ describe("searchGuides (handler)", () => {
     expect(body.guides[0].blurb).toBe("loved it");
     expect(body.guides[0].like_count).toBe(9);
     expect(body.guides[0].url).toBe("https://wanderlog.com/view/abc");
+    // edited_at is now in concise; without a wire value it's null:
+    expect(body.guides[0].edited_at).toBeNull();
+    expect(body.guides[0].start_date).toBeNull();
+    expect(body.guides[0].end_date).toBeNull();
     // Detailed-only fields remain undefined:
     expect(body.guides[0].author_name).toBeUndefined();
     expect(body.guides[0].distinction).toBeUndefined();
-    expect(body.guides[0].edited_at).toBeUndefined();
   });
 });

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -5,8 +5,9 @@ import {
   loadGoodGuides,
   projectGuide,
   resolveGeo,
+  searchGuides,
 } from "../../src/tools/search-guides.js";
-import type { GeoWithGoodGuides, WanderlogGuide } from "../../src/types.js";
+import type { GeoWithGoodGuides, GuidesForGeoResponse, WanderlogGuide } from "../../src/types.js";
 
 function fakeCtx(overrides: Partial<AppContext["rest"]> = {}): AppContext {
   return {
@@ -156,5 +157,124 @@ describe("projectGuide", () => {
     const p = projectGuide(sparse, "concise");
     expect(p.place_count).toBeNull();
     expect(p.view_count).toBeNull();
+  });
+});
+
+function handlerCtx(
+  overrides: Partial<AppContext["rest"]> = {},
+): AppContext {
+  return {
+    rest: {
+      geoAutocomplete: async () => [],
+      getGeo: async () => ({ id: 0, name: "" }),
+      listGoodGuides: async () => [] as GeoWithGoodGuides[],
+      getGuidesForGeo: async (): Promise<GuidesForGeoResponse> => ({
+        geo: { id: 0, name: "" } as GeoWithGoodGuides,
+        guides: [],
+      }),
+      ...overrides,
+    },
+  } as unknown as AppContext;
+}
+
+describe("searchGuides (handler)", () => {
+  it("rejects when neither destination nor geo_id is set", async () => {
+    __resetCacheForTests();
+    const res = await searchGuides(handlerCtx(), {});
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toMatch(/exactly one of/i);
+  });
+
+  it("rejects when both modes are set", async () => {
+    __resetCacheForTests();
+    const res = await searchGuides(handlerCtx(), {
+      destination: "Vietnam",
+      geo_id: 86655,
+    });
+    expect(res.isError).toBe(true);
+  });
+
+  it("returns kind=guides with projected entries when geo has guides", async () => {
+    __resetCacheForTests();
+    const goodGuides: GeoWithGoodGuides[] = [
+      { id: 86655, name: "Vietnam", subcategory: "country", popularity: 0 },
+    ];
+    const guide: WanderlogGuide = {
+      id: 1,
+      keyType: "view",
+      key: "abc",
+      type: "recommendations",
+      title: "Vietnam Loop",
+      user: { id: 1, username: "u", name: "U" },
+      placeCount: 42,
+      viewCount: 1234,
+    };
+    const ctx = handlerCtx({
+      geoAutocomplete: async () => [
+        { id: 86655, name: "Vietnam", countryName: null, popularity: 100, latitude: 0, longitude: 0 },
+      ],
+      listGoodGuides: async () => goodGuides,
+      getGuidesForGeo: async () => ({ geo: goodGuides[0]!, guides: [guide] }),
+    });
+    const res = await searchGuides(ctx, { destination: "Vietnam" });
+    expect(res.isError).toBeUndefined();
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.kind).toBe("guides");
+    expect(body.geo.geo_id).toBe(86655);
+    expect(body.guides).toHaveLength(1);
+    expect(body.guides[0].guide_key).toBe("abc");
+    expect(body.guides[0].title).toBe("Vietnam Loop");
+  });
+
+  it("returns kind=no_guides with up-to-5 alternatives when geo is not curated", async () => {
+    __resetCacheForTests();
+    const goodGuides: GeoWithGoodGuides[] = [
+      { id: 86647, name: "Japan", subcategory: "country", popularity: 0 },
+      { id: 9614, name: "Paris", countryName: "France", subcategory: "city", popularity: 857235 },
+      { id: 9613, name: "London", countryName: "United Kingdom", subcategory: "city", popularity: 1055882 },
+      { id: 58144, name: "New York City", countryName: "United States", subcategory: "city", popularity: 1056637 },
+      { id: 9625, name: "Amsterdam", countryName: "The Netherlands", subcategory: "city", popularity: 400126 },
+      { id: 88419, name: "Iceland", subcategory: "country", popularity: 0 },
+    ];
+    const ctx = handlerCtx({
+      geoAutocomplete: async () => [
+        { id: 9999, name: "Smalltown", countryName: "X", popularity: 10, latitude: 0, longitude: 0 },
+      ],
+      listGoodGuides: async () => goodGuides,
+    });
+    const res = await searchGuides(ctx, { destination: "Smalltown" });
+    expect(res.isError).toBeUndefined();
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.kind).toBe("no_guides");
+    expect(body.resolved_geo.geo_id).toBe(9999);
+    expect(body.alternative_geos_with_guides).toHaveLength(5);
+    // Highest popularity first:
+    expect(body.alternative_geos_with_guides[0].name).toBe("New York City");
+  });
+
+  it("concise format omits blurb/like_count/etc on each guide", async () => {
+    __resetCacheForTests();
+    const goodGuides: GeoWithGoodGuides[] = [
+      { id: 86655, name: "Vietnam", subcategory: "country", popularity: 0 },
+    ];
+    const guide: WanderlogGuide = {
+      id: 1,
+      keyType: "view",
+      key: "abc",
+      type: "recommendations",
+      title: "Vietnam Loop",
+      user: { id: 1, username: "u", name: "U" },
+      authorBlurb: "loved it",
+      likeCount: 9,
+    };
+    const ctx = handlerCtx({
+      getGeo: async (id) => ({ id, name: "Vietnam" }),
+      listGoodGuides: async () => goodGuides,
+      getGuidesForGeo: async () => ({ geo: goodGuides[0]!, guides: [guide] }),
+    });
+    const res = await searchGuides(ctx, { geo_id: 86655, response_format: "concise" });
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.guides[0].blurb).toBeUndefined();
+    expect(body.guides[0].like_count).toBeUndefined();
   });
 });

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -13,9 +13,7 @@ function fakeCtx(overrides: Partial<AppContext["rest"]> = {}): AppContext {
   return {
     rest: {
       geoAutocomplete: async () => [],
-      getGeo: async () => {
-        throw new Error("getGeo not stubbed");
-      },
+      listGoodGuides: async () => [],
       ...overrides,
     },
   } as unknown as AppContext;
@@ -42,14 +40,12 @@ describe("search-guides resolveGeo", () => {
     });
   });
 
-  it("uses getGeo for explicit geo_id and returns no alternatives", async () => {
+  it("looks up geo_id in listGoodGuides and returns no alternatives", async () => {
+    __resetCacheForTests();
     const ctx = fakeCtx({
-      getGeo: async (id: number) => ({
-        id,
-        name: "Vietnam",
-        countryName: null,
-        bounds: [1, 2, 3, 4] as [number, number, number, number],
-      }),
+      listGoodGuides: async () => [
+        { id: 86655, name: "Vietnam", countryName: null, popularity: 100, subcategory: "country" },
+      ],
     });
     const result = await resolveGeo(ctx, { geo_id: 86655 });
     expect(result.geo.geo_id).toBe(86655);
@@ -166,7 +162,6 @@ function handlerCtx(
   return {
     rest: {
       geoAutocomplete: async () => [],
-      getGeo: async () => ({ id: 0, name: "" }),
       listGoodGuides: async () => [] as GeoWithGoodGuides[],
       getGuidesForGeo: async (): Promise<GuidesForGeoResponse> => ({
         geo: { id: 0, name: "" } as GeoWithGoodGuides,
@@ -268,7 +263,6 @@ describe("searchGuides (handler)", () => {
       likeCount: 9,
     };
     const ctx = handlerCtx({
-      getGeo: async (id) => ({ id, name: "Vietnam" }),
       listGoodGuides: async () => goodGuides,
       getGuidesForGeo: async () => ({ geo: goodGuides[0]!, guides: [guide] }),
     });

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.js";
+import { resolveGeo } from "../../src/tools/search-guides.js";
+
+function fakeCtx(overrides: Partial<AppContext["rest"]> = {}): AppContext {
+  return {
+    rest: {
+      geoAutocomplete: async () => [],
+      getGeo: async () => {
+        throw new Error("getGeo not stubbed");
+      },
+      ...overrides,
+    },
+  } as unknown as AppContext;
+}
+
+describe("search-guides resolveGeo", () => {
+  it("auto-picks highest-popularity candidate and returns top 2 as alternatives", async () => {
+    const ctx = fakeCtx({
+      geoAutocomplete: async () => [
+        { id: 1, name: "Vietnam", countryName: null, popularity: 5, latitude: 0, longitude: 0 },
+        { id: 2, name: "Vietnam", countryName: null, popularity: 95, latitude: 0, longitude: 0 },
+        { id: 3, name: "Vietnam-ish", countryName: null, popularity: 50, latitude: 0, longitude: 0 },
+      ],
+    });
+    const result = await resolveGeo(ctx, { destination: "Vietnam" });
+    expect(result.geo.geo_id).toBe(2);
+    expect(result.alternative_geos.map((g) => g.geo_id)).toEqual([3, 1]);
+  });
+
+  it("throws destination_not_found when geoAutocomplete returns []", async () => {
+    const ctx = fakeCtx({ geoAutocomplete: async () => [] });
+    await expect(resolveGeo(ctx, { destination: "Nowhere" })).rejects.toMatchObject({
+      code: "destination_not_found",
+    });
+  });
+
+  it("uses getGeo for explicit geo_id and returns no alternatives", async () => {
+    const ctx = fakeCtx({
+      getGeo: async (id: number) => ({
+        id,
+        name: "Vietnam",
+        countryName: null,
+        bounds: [1, 2, 3, 4] as [number, number, number, number],
+      }),
+    });
+    const result = await resolveGeo(ctx, { geo_id: 86655 });
+    expect(result.geo.geo_id).toBe(86655);
+    expect(result.geo.name).toBe("Vietnam");
+    expect(result.alternative_geos).toEqual([]);
+  });
+});

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -40,16 +40,11 @@ describe("search-guides resolveGeo", () => {
     });
   });
 
-  it("looks up geo_id in listGoodGuides and returns no alternatives", async () => {
-    __resetCacheForTests();
-    const ctx = fakeCtx({
-      listGoodGuides: async () => [
-        { id: 86655, name: "Vietnam", countryName: null, popularity: 100, subcategory: "country" },
-      ],
-    });
+  it("returns stub geo for explicit geo_id (handler fills in canonical name from getGuidesForGeo)", async () => {
+    const ctx = fakeCtx({});
     const result = await resolveGeo(ctx, { geo_id: 86655 });
     expect(result.geo.geo_id).toBe(86655);
-    expect(result.geo.name).toBe("Vietnam");
+    expect(result.geo.name).toBe("");
     expect(result.alternative_geos).toEqual([]);
   });
 });
@@ -221,7 +216,7 @@ describe("searchGuides (handler)", () => {
     expect(body.guides[0].title).toBe("Vietnam Loop");
   });
 
-  it("returns kind=no_guides with up-to-5 alternatives when geo is not curated", async () => {
+  it("returns kind=no_guides with up-to-5 alternatives when getGuidesForGeo returns no guides", async () => {
     __resetCacheForTests();
     const goodGuides: GeoWithGoodGuides[] = [
       { id: 86647, name: "Japan", subcategory: "country", popularity: 0 },
@@ -236,6 +231,10 @@ describe("searchGuides (handler)", () => {
         { id: 9999, name: "Smalltown", countryName: "X", popularity: 10, latitude: 0, longitude: 0 },
       ],
       listGoodGuides: async () => goodGuides,
+      // Simulate Wanderlog returning no guides for this geo: 404 → throw.
+      getGuidesForGeo: async () => {
+        throw new (await import("../../src/errors.ts")).WanderlogNotFoundError("Guides", "9999");
+      },
     });
     const res = await searchGuides(ctx, { destination: "Smalltown" });
     expect(res.isError).toBeUndefined();
@@ -245,6 +244,46 @@ describe("searchGuides (handler)", () => {
     expect(body.alternative_geos_with_guides).toHaveLength(5);
     // Highest popularity first:
     expect(body.alternative_geos_with_guides[0].name).toBe("New York City");
+  });
+
+  it("returns kind=guides for a destination that is NOT in the curated list but DOES have user guides (Bangkok case)", async () => {
+    __resetCacheForTests();
+    const goodGuides: GeoWithGoodGuides[] = [
+      { id: 86647, name: "Japan", subcategory: "country", popularity: 0 },
+    ];
+    const bangkokGeo: GeoWithGoodGuides = {
+      id: 4,
+      name: "Bangkok",
+      countryName: "Thailand",
+      subcategory: "city",
+      popularity: 347007,
+    };
+    const guide: WanderlogGuide = {
+      id: 163218,
+      keyType: "view",
+      key: "vyxcbmqruh",
+      type: "recommendations",
+      title: "Bangkok, Thailand Guide",
+      user: { id: 87618, username: "sams", name: "Sam's Thailand Travels" },
+      placeCount: 77,
+      viewCount: 20320,
+    };
+    const ctx = handlerCtx({
+      geoAutocomplete: async () => [
+        { id: 4, name: "Bangkok", countryName: "Thailand", popularity: 347007, latitude: 0, longitude: 0 },
+      ],
+      listGoodGuides: async () => goodGuides,
+      getGuidesForGeo: async () => ({ geo: bangkokGeo, guides: [guide] }),
+    });
+    const res = await searchGuides(ctx, { destination: "Bangkok" });
+    expect(res.isError).toBeUndefined();
+    const body = JSON.parse(res.content[0]!.text);
+    expect(body.kind).toBe("guides");
+    expect(body.geo.geo_id).toBe(4);
+    expect(body.geo.name).toBe("Bangkok");
+    expect(body.geo.country).toBe("Thailand");
+    expect(body.geo.subcategory).toBe("city");
+    expect(body.guides[0].guide_key).toBe("vyxcbmqruh");
   });
 
   it("concise format omits blurb/like_count/etc on each guide", async () => {

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -113,7 +113,7 @@ describe("projectGuide", () => {
     headerImageKey: "yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW",
   };
 
-  it("concise projection keeps essentials, blurb, like_count, url, and dates", () => {
+  it("concise projection keeps essentials, blurb, like_count, url, and edited_at", () => {
     const p = projectGuide(raw, "concise");
     expect(p.guide_key).toBe("nlcviusycz");
     expect(p.title).toBe("Japan: Video Game Guide");
@@ -124,8 +124,6 @@ describe("projectGuide", () => {
     expect(p.blurb).toBe("I love Japan.");
     expect(p.url).toBe("https://wanderlog.com/view/nlcviusycz");
     expect(p.edited_at).toBe("2026-05-03T02:05:37+00:00");
-    expect(p.start_date).toBeNull();
-    expect(p.end_date).toBeNull();
     // 'detailed' fields stay undefined in concise mode:
     expect(p.author_name).toBeUndefined();
     expect(p.profile_picture_url).toBeUndefined();
@@ -145,22 +143,6 @@ describe("projectGuide", () => {
     expect(p.distinction).toBe("verified");
     expect(p.profile_picture_url).toMatch(/Vlp9auuKUEkRrlRR/);
     expect(p.header_image_url).toMatch(/yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW/);
-  });
-
-  it("surfaces start_date and end_date when guide has a travel-date range", () => {
-    const itinerary: WanderlogGuide = {
-      id: 99,
-      keyType: "view",
-      key: "xyz",
-      type: "recommendations",
-      title: "Two weeks in Japan",
-      user: { id: 1, username: "u", name: "U" },
-      startDate: "2024-04-01",
-      endDate: "2024-04-14",
-    };
-    const p = projectGuide(itinerary, "concise");
-    expect(p.start_date).toBe("2024-04-01");
-    expect(p.end_date).toBe("2024-04-14");
   });
 
   it("nulls and missing fields stay null/undefined gracefully", () => {
@@ -341,8 +323,6 @@ describe("searchGuides (handler)", () => {
     expect(body.guides[0].url).toBe("https://wanderlog.com/view/abc");
     // edited_at is now in concise; without a wire value it's null:
     expect(body.guides[0].edited_at).toBeNull();
-    expect(body.guides[0].start_date).toBeNull();
-    expect(body.guides[0].end_date).toBeNull();
     // Detailed-only fields remain undefined:
     expect(body.guides[0].author_name).toBeUndefined();
     expect(body.guides[0].distinction).toBeUndefined();

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { AppContext } from "../../src/context.js";
-import { resolveGeo } from "../../src/tools/search-guides.js";
+import {
+  __resetCacheForTests,
+  loadGoodGuides,
+  projectGuide,
+  resolveGeo,
+} from "../../src/tools/search-guides.js";
+import type { GeoWithGoodGuides, WanderlogGuide } from "../../src/types.js";
 
 function fakeCtx(overrides: Partial<AppContext["rest"]> = {}): AppContext {
   return {
@@ -48,5 +54,107 @@ describe("search-guides resolveGeo", () => {
     expect(result.geo.geo_id).toBe(86655);
     expect(result.geo.name).toBe("Vietnam");
     expect(result.alternative_geos).toEqual([]);
+  });
+});
+
+describe("loadGoodGuides cache", () => {
+  it("calls listGoodGuides once across multiple invocations", async () => {
+    __resetCacheForTests();
+    let calls = 0;
+    const sample: GeoWithGoodGuides[] = [
+      { id: 86655, name: "Vietnam", popularity: 100, subcategory: "country" },
+    ];
+    const ctx = {
+      rest: {
+        listGoodGuides: async () => {
+          calls++;
+          return sample;
+        },
+      },
+    } as unknown as AppContext;
+
+    const first = await loadGoodGuides(ctx);
+    const second = await loadGoodGuides(ctx);
+    expect(first).toBe(second);
+    expect(calls).toBe(1);
+  });
+
+  it("clears the cached promise when the underlying call fails so the next call retries", async () => {
+    __resetCacheForTests();
+    let calls = 0;
+    const ctx = {
+      rest: {
+        listGoodGuides: async () => {
+          calls++;
+          if (calls === 1) throw new Error("network down");
+          return [];
+        },
+      },
+    } as unknown as AppContext;
+
+    await expect(loadGoodGuides(ctx)).rejects.toThrow(/network down/);
+    await loadGoodGuides(ctx); // second call should re-invoke
+    expect(calls).toBe(2);
+  });
+});
+
+describe("projectGuide", () => {
+  const raw: WanderlogGuide = {
+    id: 5325079,
+    keyType: "view",
+    key: "nlcviusycz",
+    journalKey: "x",
+    type: "recommendations",
+    title: "Japan: Video Game Guide",
+    user: {
+      id: 157169,
+      username: "pham2ez",
+      name: "2e",
+      profilePictureKey: "Vlp9auuKUEkRrlRR",
+    },
+    placeCount: 114,
+    viewCount: 186566,
+    likeCount: 2624,
+    editedAt: "2026-05-03T02:05:37+00:00",
+    distinction: "verified",
+    authorBlurb: "I love Japan.",
+    headerImageKey: "yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW",
+  };
+
+  it("concise projection keeps the essentials", () => {
+    const p = projectGuide(raw, "concise");
+    expect(p.guide_key).toBe("nlcviusycz");
+    expect(p.title).toBe("Japan: Video Game Guide");
+    expect(p.author).toBe("pham2ez");
+    expect(p.place_count).toBe(114);
+    expect(p.view_count).toBe(186566);
+    expect(p.blurb).toBeUndefined();
+    expect(p.like_count).toBeUndefined();
+    expect(p.header_image_url).toBeUndefined();
+  });
+
+  it("detailed projection adds author_name, blurb, like_count, edited_at, distinction, image URLs", () => {
+    const p = projectGuide(raw, "detailed");
+    expect(p.author_name).toBe("2e");
+    expect(p.blurb).toBe("I love Japan.");
+    expect(p.like_count).toBe(2624);
+    expect(p.edited_at).toBe("2026-05-03T02:05:37+00:00");
+    expect(p.distinction).toBe("verified");
+    expect(p.profile_picture_url).toMatch(/Vlp9auuKUEkRrlRR/);
+    expect(p.header_image_url).toMatch(/yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW/);
+  });
+
+  it("nulls and missing fields stay null/undefined gracefully", () => {
+    const sparse: WanderlogGuide = {
+      id: 1,
+      keyType: "view",
+      key: "abc",
+      type: "recommendations",
+      title: "Stub",
+      user: { id: 0, username: "u", name: "U" },
+    };
+    const p = projectGuide(sparse, "concise");
+    expect(p.place_count).toBeNull();
+    expect(p.view_count).toBeNull();
   });
 });

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { AppContext } from "../../src/context.js";
+import type { AppContext } from "../../src/context.ts";
 import {
   __resetCacheForTests,
   loadGoodGuides,
   projectGuide,
   resolveGeo,
   searchGuides,
-} from "../../src/tools/search-guides.js";
-import type { GeoWithGoodGuides, GuidesForGeoResponse, WanderlogGuide } from "../../src/types.js";
+} from "../../src/tools/search-guides.ts";
+import type { GeoWithGoodGuides, GuidesForGeoResponse, WanderlogGuide } from "../../src/types.ts";
 
 function fakeCtx(overrides: Partial<AppContext["rest"]> = {}): AppContext {
   return {

--- a/tests/unit/search-guides.test.ts
+++ b/tests/unit/search-guides.test.ts
@@ -113,23 +113,32 @@ describe("projectGuide", () => {
     headerImageKey: "yitfaNaah1Cxyrnht6TDK7dxn2U1EtMW",
   };
 
-  it("concise projection keeps the essentials", () => {
+  it("concise projection keeps essentials, blurb, like_count, and a reference url", () => {
     const p = projectGuide(raw, "concise");
     expect(p.guide_key).toBe("nlcviusycz");
     expect(p.title).toBe("Japan: Video Game Guide");
     expect(p.author).toBe("pham2ez");
     expect(p.place_count).toBe(114);
     expect(p.view_count).toBe(186566);
-    expect(p.blurb).toBeUndefined();
-    expect(p.like_count).toBeUndefined();
+    expect(p.like_count).toBe(2624);
+    expect(p.blurb).toBe("I love Japan.");
+    expect(p.url).toBe("https://wanderlog.com/view/nlcviusycz");
+    // 'detailed' fields stay undefined in concise mode:
+    expect(p.author_name).toBeUndefined();
+    expect(p.profile_picture_url).toBeUndefined();
     expect(p.header_image_url).toBeUndefined();
+    expect(p.distinction).toBeUndefined();
+    expect(p.edited_at).toBeUndefined();
   });
 
-  it("detailed projection adds author_name, blurb, like_count, edited_at, distinction, image URLs", () => {
+  it("detailed projection adds author_name, edited_at, distinction, profile + header image URLs", () => {
     const p = projectGuide(raw, "detailed");
-    expect(p.author_name).toBe("2e");
+    // base fields still present
     expect(p.blurb).toBe("I love Japan.");
     expect(p.like_count).toBe(2624);
+    expect(p.url).toBe("https://wanderlog.com/view/nlcviusycz");
+    // detailed-only:
+    expect(p.author_name).toBe("2e");
     expect(p.edited_at).toBe("2026-05-03T02:05:37+00:00");
     expect(p.distinction).toBe("verified");
     expect(p.profile_picture_url).toMatch(/Vlp9auuKUEkRrlRR/);
@@ -286,7 +295,7 @@ describe("searchGuides (handler)", () => {
     expect(body.guides[0].guide_key).toBe("vyxcbmqruh");
   });
 
-  it("concise format omits blurb/like_count/etc on each guide", async () => {
+  it("concise format includes blurb/like_count/url but omits detailed-only fields", async () => {
     __resetCacheForTests();
     const goodGuides: GeoWithGoodGuides[] = [
       { id: 86655, name: "Vietnam", subcategory: "country", popularity: 0 },
@@ -300,6 +309,7 @@ describe("searchGuides (handler)", () => {
       user: { id: 1, username: "u", name: "U" },
       authorBlurb: "loved it",
       likeCount: 9,
+      distinction: "promotable",
     };
     const ctx = handlerCtx({
       listGoodGuides: async () => goodGuides,
@@ -307,7 +317,13 @@ describe("searchGuides (handler)", () => {
     });
     const res = await searchGuides(ctx, { geo_id: 86655, response_format: "concise" });
     const body = JSON.parse(res.content[0]!.text);
-    expect(body.guides[0].blurb).toBeUndefined();
-    expect(body.guides[0].like_count).toBeUndefined();
+    // Always-present in concise:
+    expect(body.guides[0].blurb).toBe("loved it");
+    expect(body.guides[0].like_count).toBe(9);
+    expect(body.guides[0].url).toBe("https://wanderlog.com/view/abc");
+    // Detailed-only fields remain undefined:
+    expect(body.guides[0].author_name).toBeUndefined();
+    expect(body.guides[0].distinction).toBeUndefined();
+    expect(body.guides[0].edited_at).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds two read-only tools so an agent can discover and read user-written travel guides hosted on Wanderlog.

- **`wanderlog_search_guides`** — list curated user guides for a destination via `/api/geo/geosWithGoodGuides` (for fallback suggestions) and `/api/tripPlans/browse/guides/<geoId>` (for the actual content). Works for any geo with user-published guides, not just the small curated featured list.
- **`wanderlog_get_guide`** — fetch the full content of one guide via `/api/tripPlans/<key>?clientSchemaVersion=2`. Note: deliberately no `registerView=true`, so agent reads don't bump the author's view counter. Renders via the existing `formatTrip` formatter so output shape matches `wanderlog_get_trip`.

## `wanderlog_search_guides` response (concise example)

```jsonc
{
  "kind": "guides",
  "geo": { "geo_id": 4, "name": "Bangkok", "country": "Thailand", "subcategory": "city" },
  "alternative_geos": [],
  "returned": 12,
  "total": 12,
  "guides": [
    {
      "guide_key": "vyxcbmqruh",
      "title": "Bangkok, Thailand Guide",
      "author": "sams",
      "place_count": 77,
      "view_count": 20323,
      "like_count": 227,
      "blurb": "Avid Traveler Across Thailand.",
      "url": "https://wanderlog.com/view/vyxcbmqruh"
    }
  ]
}
```

When the destination has no user guides at all, the response carries `kind: "no_guides"` with `alternative_geos_with_guides` (top 5 popular curated destinations) as suggestions for the LLM.

## Design notes

- **Always-fetch-first, fallback-on-empty.** The `geosWithGoodGuides` list (~30 curated/featured destinations) is used as a **fallback suggestion source**, not as a gate. Many real destinations (Bangkok, Hoi An, etc.) aren't featured but DO have user guides — earlier iterations missed them. Now we always call `getGuidesForGeo(geoId)` first and only fall back to suggestions when guides are empty or 404.
- **Auto-pick + alternatives** for free-text destinations, same pattern as `wanderlog_add_place` and `wanderlog_search_hotels`. No separate disambiguation envelope.
- **Cached `geosWithGoodGuides`** at module scope, lazy-loaded once per process; small (~30 items) and rarely changes.
- **Reused `formatTrip`** for `wanderlog_get_guide` so output matches `wanderlog_get_trip` exactly.
- **404 hint** — `WanderlogNotFoundError("Guide", key)` steers the LLM to `wanderlog_search_guides`, not `wanderlog_list_trips`.

## Drive-by improvements to `src/formatters/trip-summary.ts`

These also affect `wanderlog_get_trip` but improve both tools:

1. **`section.text` now renders.** Sections like "About Vietnam" or "General tips" carry rich-text intros in `section.text` that the previous renderer dropped entirely (early-return when `blocks` was empty). Now both text-only and text+blocks sections render. Trips that don't use `section.text` are unaffected.
2. **Detailed mode no longer truncates place-note or note-block text.** Concise mode caps stay at 120/200 chars (the summary-grade behavior). Detailed mode drops both caps so long-form guide commentary renders in full. The previous 200-char cap in detailed mode is removed.
3. **`Section` type declares `text?: QuillDelta`** (the field was already in the wire payload, just not declared).

## Out of scope

Wanderlog also has SEO-only auto-curated pages at `/list/geoCategory/<id>/...` ("Top N things to do in X"). Those are server-rendered HTML with no clean JSON API and would require Cheerio/Playwright at runtime. Deferred to a follow-up.

## Test plan

- **Unit tests:** input validation, geo resolution (both modes), cache memoisation, `projectGuide` concise/detailed, handler success / no-guides / Bangkok-style "not in curated list but has guides" / format passthrough; `get-guide` happy path / empty key / 404 with hint / unexpected error. ~18 new vitest cases.
- **Integration test:** `tests/integration/guides.integration.test.ts` hits the live API for "New York City", asserts ≥1 guide returned, then reads that guide's content. Skipped when `WANDERLOG_COOKIE` is unset.
- `npm run typecheck && npm run build && npm run test` green (257 total).
- Live-verified against Bangkok: 12 guides returned including "Bangkok, Thailand Guide" (77 places, 20K views).
- No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)