### PR TITLE
fix: surface and retry Wanderlog ShareDB rate-limit rejections

### DIFF
--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -56,7 +56,7 @@ export async function submitOp(
       );
     }
     try {
-      await client.submit(ops);
+      await submitWithRateLimitRetry(client, ops);
       ctx.tripCache.applyLocalOp(tripKey, ops, client.version);
     } catch (err) {
       // Any submit failure leaves our cached view possibly inconsistent with
@@ -65,6 +65,35 @@ export async function submitOp(
       throw err;
     }
   });
+}
+
+const RATE_LIMIT_RETRY_DELAYS_MS = [2_000, 4_000, 8_000];
+
+// A rate-limited op (code 4001) is rejected before the server processes it —
+// it never acks and never applies — so resubmitting the same ops at the same
+// version is safe. Burst mutations (e.g. an LLM building a full itinerary)
+// hit the limit routinely; waiting out the window beats surfacing an error.
+async function submitWithRateLimitRetry(
+  client: { submit(ops: Json0Op[]): Promise<void> },
+  ops: Json0Op[],
+): Promise<void> {
+  let attempt = 0;
+  for (;;) {
+    try {
+      await client.submit(ops);
+      return;
+    } catch (err) {
+      const isRateLimit =
+        err instanceof WanderlogError && err.code === "rate_limited";
+      if (!isRateLimit || attempt >= RATE_LIMIT_RETRY_DELAYS_MS.length) {
+        throw err;
+      }
+      await new Promise((r) =>
+        setTimeout(r, RATE_LIMIT_RETRY_DELAYS_MS[attempt]),
+      );
+      attempt += 1;
+    }
+  }
 }
 
 /** Wanderlog block IDs are 9-digit numeric. */

--- a/src/tools/update-trip-dates.ts
+++ b/src/tools/update-trip-dates.ts
@@ -79,6 +79,9 @@ export function buildEmptyDaySection(date: string): Section {
     type: "normal",
     mode: "dayPlan",
     heading: "",
+    // Server-side validation requires text on sections — an li without it gets
+    // silently dropped (no ack, submit times out).
+    text: { ops: [{ insert: "\n" }] },
     date,
     blocks: [],
     placeMarkerColor: "#3498db",

--- a/src/transport/sharedb.ts
+++ b/src/transport/sharedb.ts
@@ -181,10 +181,26 @@ export class ShareDBClient extends EventEmitter {
   }
 
   private handleFrame(
-    frame: Frame & { error?: unknown; seq?: number },
+    frame: Frame & { error?: unknown; seq?: number; code?: number; message?: string },
     handshakeTimeout: NodeJS.Timeout,
     connectResolve: () => void,
   ): void {
+    // Server rejections arrive as bare {code, message} frames with no `a` and
+    // no `seq` (observed: {code: 4001, message: "Too many requests"}). Without
+    // this branch they fall through silently and the submit dies as an opaque
+    // 10s timeout. No seq means we can't attribute it — fail everything.
+    const bare = frame as { a?: string; code?: number; message?: string };
+    if (bare.a === undefined && typeof bare.code === "number") {
+      const code = bare.code === 4001 ? "rate_limited" : "ws_rejected";
+      this.failAllPending(
+        new WanderlogError(
+          `Wanderlog rejected the request (${bare.code}): ${bare.message ?? "unknown"}`,
+          code,
+        ),
+      );
+      return;
+    }
+
     if (frame.error) {
       const err = frame.error as string | { message?: string };
       const errMsg = typeof err === "string" ? err : err.message ?? "unknown";

--- a/tests/integration/mcp-smoke.test.ts
+++ b/tests/integration/mcp-smoke.test.ts
@@ -87,7 +87,7 @@ describe("MCP stdio server (smoke)", () => {
     expect(p.pid).toBeDefined();
   });
 
-  it("responds to tools/list with all 9 tools", async () => {
+  it("responds to tools/list with all 18 tools", async () => {
     const p = startServer();
     await waitForReady(p);
     await initialize(p);
@@ -101,14 +101,21 @@ describe("MCP stdio server (smoke)", () => {
     const names = resp.result.tools.map((t: { name: string }) => t.name).sort();
     expect(names).toEqual([
       "wanderlog_add_checklist",
+      "wanderlog_add_expense",
       "wanderlog_add_hotel",
       "wanderlog_add_note",
       "wanderlog_add_place",
+      "wanderlog_annotate_place",
       "wanderlog_create_trip",
+      "wanderlog_edit_note",
+      "wanderlog_get_guide",
       "wanderlog_get_trip",
       "wanderlog_get_trip_url",
       "wanderlog_list_trips",
+      "wanderlog_remove_note",
       "wanderlog_remove_place",
+      "wanderlog_rename_day",
+      "wanderlog_search_guides",
       "wanderlog_search_places",
       "wanderlog_update_trip_dates",
     ]);

--- a/tests/unit/rate-limit-retry.test.ts
+++ b/tests/unit/rate-limit-retry.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import { WanderlogError } from "../../src/errors.ts";
+import type { Json0Op } from "../../src/ot/apply.ts";
+import { submitOp } from "../../src/tools/shared.ts";
+import { ShareDBClient } from "../../src/transport/sharedb.ts";
+
+const ops: Json0Op[] = [{ p: ["days"], od: 3, oi: 5 }];
+
+function makeFakeContext(failures: Array<Error | null>): {
+  ctx: AppContext;
+  submitCalls: () => number;
+  invalidateCount: () => number;
+  applyLocalOpCount: () => number;
+} {
+  let callIndex = 0;
+  let invalidateCount = 0;
+  let applyLocalOpCount = 0;
+
+  const fakeClient = {
+    isSubscribed: true,
+    version: 0,
+    async submit(_ops: Json0Op[]): Promise<void> {
+      const failure = failures[callIndex++];
+      if (failure) throw failure;
+      this.version += 1;
+    },
+  };
+
+  const ctx = {
+    pool: { get: () => fakeClient },
+    tripCache: {
+      applyLocalOp: () => {
+        applyLocalOpCount++;
+      },
+      invalidate: () => {
+        invalidateCount++;
+      },
+    },
+  } as unknown as AppContext;
+
+  return {
+    ctx,
+    submitCalls: () => callIndex,
+    invalidateCount: () => invalidateCount,
+    applyLocalOpCount: () => applyLocalOpCount,
+  };
+}
+
+const rateLimitError = () =>
+  new WanderlogError(
+    "Wanderlog rejected the request (4001): Too many requests",
+    "rate_limited",
+  );
+
+describe("submitOp rate-limit retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries after a rate_limited error and succeeds", async () => {
+    const fake = makeFakeContext([rateLimitError(), null]);
+    const promise = submitOp(fake.ctx, "tripA", ops);
+    await vi.advanceTimersByTimeAsync(2_000);
+    await promise;
+    expect(fake.submitCalls()).toBe(2);
+    expect(fake.applyLocalOpCount()).toBe(1);
+    expect(fake.invalidateCount()).toBe(0);
+  });
+
+  it("gives up after exhausting retries and invalidates the cache", async () => {
+    const fake = makeFakeContext([
+      rateLimitError(),
+      rateLimitError(),
+      rateLimitError(),
+      rateLimitError(),
+    ]);
+    const promise = submitOp(fake.ctx, "tripA", ops);
+    const assertion = expect(promise).rejects.toMatchObject({
+      code: "rate_limited",
+    });
+    await vi.advanceTimersByTimeAsync(2_000 + 4_000 + 8_000);
+    await assertion;
+    expect(fake.submitCalls()).toBe(4);
+    expect(fake.applyLocalOpCount()).toBe(0);
+    expect(fake.invalidateCount()).toBe(1);
+  });
+
+  it("does not retry non-rate-limit errors", async () => {
+    const fake = makeFakeContext([
+      new WanderlogError("Submit op timeout", "submit_timeout"),
+    ]);
+    await expect(submitOp(fake.ctx, "tripA", ops)).rejects.toMatchObject({
+      code: "submit_timeout",
+    });
+    expect(fake.submitCalls()).toBe(1);
+    expect(fake.invalidateCount()).toBe(1);
+  });
+});
+
+describe("ShareDBClient bare {code, message} rejection frames", () => {
+  const config = {
+    cookieHeader: "connect.sid=test",
+    baseUrl: "https://example.test",
+    wsBaseUrl: "wss://example.test",
+    userAgent: "test",
+  };
+
+  function clientWithPendingOp(): {
+    client: ShareDBClient;
+    pending: Promise<void>;
+  } {
+    const client = new ShareDBClient(config, "tripA");
+    const internals = client as unknown as {
+      pendingOps: Map<
+        number,
+        { resolve: () => void; reject: (err: Error) => void; timer: NodeJS.Timeout }
+      >;
+      handleFrame: (
+        frame: Record<string, unknown>,
+        handshakeTimeout: NodeJS.Timeout,
+        connectResolve: () => void,
+      ) => void;
+    };
+    const pending = new Promise<void>((resolve, reject) => {
+      internals.pendingOps.set(1, {
+        resolve,
+        reject,
+        timer: setTimeout(() => {}, 60_000),
+      });
+    });
+    return { client, pending };
+  }
+
+  function deliverFrame(client: ShareDBClient, frame: Record<string, unknown>) {
+    (
+      client as unknown as {
+        handleFrame: (
+          frame: Record<string, unknown>,
+          handshakeTimeout: NodeJS.Timeout,
+          connectResolve: () => void,
+        ) => void;
+      }
+    ).handleFrame(frame, setTimeout(() => {}, 60_000), () => {});
+  }
+
+  it("maps code 4001 to a rate_limited error on pending ops", async () => {
+    const { client, pending } = clientWithPendingOp();
+    deliverFrame(client, {
+      code: 4001,
+      message: "Too many requests; please try again later",
+    });
+    await expect(pending).rejects.toMatchObject({ code: "rate_limited" });
+  });
+
+  it("maps other bare codes to ws_rejected", async () => {
+    const { client, pending } = clientWithPendingOp();
+    deliverFrame(client, { code: 4999, message: "nope" });
+    await expect(pending).rejects.toMatchObject({ code: "ws_rejected" });
+  });
+
+  it("does not treat op acks (which carry `a`) as rejections", async () => {
+    const { client, pending } = clientWithPendingOp();
+    const internals = client as unknown as { sessionId?: string };
+    internals.sessionId = "session-1";
+    deliverFrame(client, {
+      a: "op",
+      src: "session-1",
+      seq: 1,
+      v: 7,
+      c: "TripPlans",
+      d: "tripA",
+    });
+    await expect(pending).resolves.toBeUndefined();
+    expect(client.version).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary

Wanderlog rate-limits rapid ShareDB ops (~9 mutations in quick succession) by replying with a bare `{code: 4001, message: "Too many requests"}` frame — no `a`, no `seq`, no `error` field. `handleFrame` fell through every branch and silently dropped it, so the submit died as an opaque 10s "Submit op timeout". This is why the `update_trip_dates` extend integration test failed consistently: it's the 9th mutation in the suite's burst, not a malformed op (verified by replaying the identical op batch in isolation — it acks instantly).

- `sharedb.ts`: recognize bare `{code, message}` rejection frames → `rate_limited` (4001) / `ws_rejected`. No seq means the rejection can't be attributed to one submit, so `failAllPending` — consistent with invariant 10's fallback clause.
- `shared.ts`: `submitOp` retries rate-limited submits with 2s/4s/8s backoff. Safe to resubmit identical ops at the same version: a 4001'd op is rejected before processing — never acked, never applied. Burst mutations are wanderdog's core use case (an LLM building a full itinerary), so waiting out the window beats erroring.
- `update-trip-dates.ts`: `buildEmptyDaySection` now includes `text: {ops:[{insert:"\n"}]}`, matching real Wanderlog sections and every other block builder.
- `mcp-smoke.test.ts`: stale `tools/list` assertion updated (9 → 18 tools).

## Test plan

- New `tests/unit/rate-limit-retry.test.ts` (6 tests, fake timers): retry-then-succeed, retry exhaustion (cache invalidated, error surfaces), no retry on other errors, 4001→`rate_limited` mapping, other codes→`ws_rejected`, op acks still resolve normally.
- Reproduced the bug against live wanderlog.com with a raw WS script (captured the 4001 frame on the 9th rapid op), then confirmed the fix: `npm run test:integration` now 32/32 including the two previously-failing `update_trip_dates` tests.
- `npm run build && npm run test`: 263/263.

## Agent-facing surface changes

- [x] Changed a tool description, parameter doc, or error message — new error text `Wanderlog rejected the request (4001): Too many requests...` can reach the LLM on retry exhaustion. Plain wire-derived text, no injection surface beyond what the server already controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)