### PR TITLE
feat: add list/remove/edit expense tools; allow unlinked expenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ and a ryokan in Shinjuku."
 | `wanderlog_remove_note` | Remove a standalone note block by natural-language reference |
 | `wanderlog_add_hotel` | Add a hotel booking with check-in/check-out dates |
 | `wanderlog_add_checklist` | Add a pre-trip or per-day checklist |
-| `wanderlog_add_expense` | Log a budget expense (amount, category, currency) linked to a place |
+| `wanderlog_add_expense` | Log a budget expense (amount, category, currency), optionally linked to a place |
+| `wanderlog_list_expenses` | List budget expenses, optionally filtered by description / date / amount / currency |
+| `wanderlog_remove_expense` | Remove a budget expense by description (with optional date / amount / currency filters) |
+| `wanderlog_edit_expense` | Change a budget expense's description, amount, currency, category, or date |
 | `wanderlog_annotate_place` | Update an existing place with a note, start/end time, or both |
 | `wanderlog_remove_place` | Remove a place by natural-language reference |
 | `wanderlog_update_trip_dates` | Change a trip's date range |

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,6 +81,21 @@ import {
   removeNoteInputSchema,
 } from "./tools/remove-note.js";
 import {
+  listExpenses,
+  listExpensesDescription,
+  listExpensesInputSchema,
+} from "./tools/list-expenses.js";
+import {
+  removeExpense,
+  removeExpenseDescription,
+  removeExpenseInputSchema,
+} from "./tools/remove-expense.js";
+import {
+  editExpense,
+  editExpenseDescription,
+  editExpenseInputSchema,
+} from "./tools/edit-expense.js";
+import {
   searchGuides,
   searchGuidesDescription,
   searchGuidesInputSchema,
@@ -286,6 +301,39 @@ export function buildServer(ctx: AppContext): McpServer {
     },
     requireAuth(ctx, async (args) =>
       addExpense(ctx, args as Parameters<typeof addExpense>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_list_expenses",
+    {
+      title: "List budget expenses on a Wanderlog trip",
+      description: listExpensesDescription,
+      inputSchema: listExpensesInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      listExpenses(ctx, args as Parameters<typeof listExpenses>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_remove_expense",
+    {
+      title: "Remove a budget expense from a Wanderlog trip",
+      description: removeExpenseDescription,
+      inputSchema: removeExpenseInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      removeExpense(ctx, args as Parameters<typeof removeExpense>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_edit_expense",
+    {
+      title: "Edit a budget expense on a Wanderlog trip",
+      description: editExpenseDescription,
+      inputSchema: editExpenseInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      editExpense(ctx, args as Parameters<typeof editExpense>[1])),
   );
 
   server.registerTool(

--- a/src/tools/add-expense.ts
+++ b/src/tools/add-expense.ts
@@ -45,8 +45,9 @@ export const addExpenseInputSchema = {
   place: z
     .string()
     .min(1)
+    .optional()
     .describe(
-      "Natural-language reference to link this expense to a place in the trip (e.g. 'Sensō-ji', 'the hotel'). Required — every expense must be linked to a place.",
+      "Optional natural-language reference to link this expense to a place in the trip (e.g. 'Sensō-ji', 'the hotel'). Omit to log an unlinked expense (counts toward the budget total but isn't attached to a place).",
     ),
   date: z
     .string()
@@ -56,11 +57,11 @@ export const addExpenseInputSchema = {
 };
 
 export const addExpenseDescription = `
-Adds a budget expense to a Wanderlog trip linked to a specific place. Expenses appear in the
-trip's budget tracker on the linked place.
+Adds a budget expense to a Wanderlog trip. Optionally links the expense to a place so it shows up
+on that place in the budget tracker; omit "place" to log a standalone (unlinked) expense.
 
-Use this after adding places to give the trip a cost dimension — estimated meal costs, entrance
-fees, transport passes, etc. The place must already exist in the trip.
+Use this to give the trip a cost dimension — estimated meal costs, entrance fees, transport
+passes, etc. If you link a place, it must already exist in the trip.
 
 Returns confirmation with the expense amount and description.
 `.trim();
@@ -71,7 +72,7 @@ type Args = {
   currency: string;
   category: string;
   description: string;
-  place: string;
+  place?: string;
   date?: string;
 };
 
@@ -84,32 +85,36 @@ export async function addExpense(
     const entry = await ctx.tripCache.getEntry(args.trip_key);
     const trip = entry.snapshot;
 
-    // Every expense must be linked to a place — Wanderlog's UI crashes on
-    // unlinked expenses (blockId: null triggers an undefined .text access).
-    const result = resolvePlaceRef(trip, args.place);
-    if (result.kind === "ambiguous") {
-      const lines = result.candidates.map((c, i) => {
-        const name = isPlaceBlock(c.block) ? c.block.place.name : `block #${c.block.id}`;
-        const loc = c.section.date ? `day ${c.section.date}` : c.section.heading || "unscheduled";
-        return `  ${i + 1}. ${name} (${loc})`;
-      });
-      const text = `Multiple places match "${args.place}":\n${lines.join("\n")}\n\nRetry with a more specific reference.`;
-      return { content: [{ type: "text", text }] };
+    // Linking to a place is optional — Wanderlog accepts unlinked expenses
+    // (blockId: null), which appear in the budget total without a place.
+    let blockId: number | null = null;
+    let associatedDate: string | null = null;
+    if (args.place) {
+      const result = resolvePlaceRef(trip, args.place);
+      if (result.kind === "ambiguous") {
+        const lines = result.candidates.map((c, i) => {
+          const name = isPlaceBlock(c.block) ? c.block.place.name : `block #${c.block.id}`;
+          const loc = c.section.date ? `day ${c.section.date}` : c.section.heading || "unscheduled";
+          return `  ${i + 1}. ${name} (${loc})`;
+        });
+        const text = `Multiple places match "${args.place}":\n${lines.join("\n")}\n\nRetry with a more specific reference.`;
+        return { content: [{ type: "text", text }] };
+      }
+      if (result.kind === "none") {
+        throw new WanderlogError(
+          `No place matching "${args.place}" found in "${trip.title}"`,
+          "place_ref_not_found",
+          {
+            hint: "Add the place to the trip first with wanderlog_add_place, or omit 'place' to log an unlinked expense.",
+            followUps: [
+              `Call wanderlog_get_trip with trip_key "${args.trip_key}" to see existing places.`,
+            ],
+          },
+        );
+      }
+      blockId = result.match.block.id;
+      associatedDate = result.match.section.date;
     }
-    if (result.kind === "none") {
-      throw new WanderlogError(
-        `No place matching "${args.place}" found in "${trip.title}"`,
-        "place_ref_not_found",
-        {
-          hint: "Add the place to the trip first with wanderlog_add_place, then add the expense.",
-          followUps: [
-            `Call wanderlog_get_trip with trip_key "${args.trip_key}" to see existing places.`,
-          ],
-        },
-      );
-    }
-    const blockId = result.match.block.id;
-    const associatedDate = result.match.section.date;
 
     const expenseDate = args.date ?? new Date().toISOString().slice(0, 10);
 
@@ -147,7 +152,8 @@ export async function addExpense(
     await submitOp(ctx, args.trip_key, ops);
 
     const currencyLabel = args.currency.toUpperCase();
-    const text = `Added expense: ${currencyLabel} ${args.amount} for "${args.description}" (linked to ${args.place}) in "${trip.title}".`;
+    const linkLabel = args.place ? ` (linked to ${args.place})` : "";
+    const text = `Added expense: ${currencyLabel} ${args.amount} for "${args.description}"${linkLabel} in "${trip.title}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/edit-expense.ts
+++ b/src/tools/edit-expense.ts
@@ -1,0 +1,233 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError, WanderlogValidationError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import type { Expense } from "../types.js";
+import {
+  findExpenseMatches,
+  formatCandidateList,
+  formatExpense,
+} from "./expenses-shared.js";
+import { submitOp } from "./shared.js";
+
+export const editExpenseInputSchema = {
+  trip_key: z.string().min(1).describe("The trip whose expense to edit."),
+  description: z
+    .string()
+    .min(1)
+    .describe("Case-insensitive substring matching the description of the expense to edit."),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Optional exact date filter to disambiguate which expense to edit."),
+  amount: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Optional exact amount filter to disambiguate which expense to edit."),
+  currency: z
+    .string()
+    .min(3)
+    .max(3)
+    .optional()
+    .describe("Optional ISO 4217 currency filter to disambiguate which expense to edit."),
+  new_description: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("New description text. Omit to leave unchanged."),
+  new_amount: z
+    .number()
+    .positive()
+    .optional()
+    .describe("New cost amount (e.g. 50, 12.50). Omit to leave unchanged."),
+  new_currency: z
+    .string()
+    .min(3)
+    .max(3)
+    .optional()
+    .describe("New ISO 4217 currency code (e.g. 'EUR'). Normalized to uppercase. Omit to leave unchanged."),
+  new_category: z
+    .enum([
+      "food",
+      "drinks",
+      "groceries",
+      "publicTransit",
+      "carRental",
+      "gas",
+      "flights",
+      "lodging",
+      "sightseeing",
+      "activities",
+      "shopping",
+      "other",
+    ])
+    .optional()
+    .describe("New expense category. Omit to leave unchanged."),
+  new_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe(
+      "New date for the expense, YYYY-MM-DD. Updates both the expense date and the budget day it's grouped under (Wanderlog's budget list displays this date). Omit to leave unchanged.",
+    ),
+};
+
+export const editExpenseDescription = `
+Edits an existing budget expense on a Wanderlog trip. Find the expense by a case-insensitive
+substring of its description, then change any of: description, amount, currency, category, date.
+
+If none match, an error is returned. If several match, a numbered list is returned and nothing is
+changed — narrow with a more specific description or a date / amount / currency filter. Only the
+fields you supply via new_* are modified; all other fields on the expense are preserved.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  description: string;
+  date?: string;
+  amount?: number;
+  currency?: string;
+  new_description?: string;
+  new_amount?: number;
+  new_currency?: string;
+  new_category?: string;
+  new_date?: string;
+};
+
+/** od+oi replacement for an existing key; oi-only insert when the key is absent. */
+function replaceField(
+  path: (string | number)[],
+  oldValue: unknown,
+  newValue: unknown,
+): Json0Op {
+  return oldValue === undefined ? { p: path, oi: newValue } : { p: path, od: oldValue, oi: newValue };
+}
+
+function buildEditOps(
+  expense: Expense,
+  index: number,
+  args: Args,
+): { ops: Json0Op[]; changes: string[] } {
+  const base = ["itinerary", "budget", "expenses", index];
+  const ops: Json0Op[] = [];
+  const changes: string[] = [];
+
+  if (args.new_description !== undefined && args.new_description !== expense.description) {
+    ops.push(replaceField([...base, "description"], expense.description, args.new_description));
+    changes.push(`description → "${args.new_description}"`);
+  }
+
+  if (args.new_category !== undefined && args.new_category !== expense.category) {
+    ops.push(replaceField([...base, "category"], expense.category, args.new_category));
+    changes.push(`category → ${args.new_category}`);
+  }
+
+  if (args.new_amount !== undefined && args.new_amount !== expense.amount?.amount) {
+    ops.push(replaceField([...base, "amount", "amount"], expense.amount?.amount, args.new_amount));
+    changes.push(`amount → ${args.new_amount}`);
+  }
+
+  if (args.new_currency !== undefined) {
+    const normalized = args.new_currency.toUpperCase();
+    if (normalized !== expense.amount?.currencyCode) {
+      ops.push(
+        replaceField([...base, "amount", "currencyCode"], expense.amount?.currencyCode, normalized),
+      );
+      changes.push(`currency → ${normalized}`);
+    }
+  }
+
+  if (args.new_date !== undefined) {
+    // Wanderlog's budget list displays `associatedDate` (the trip day the
+    // expense is grouped under), not `date`, so keep both in sync.
+    const dateChanged = args.new_date !== expense.date;
+    const assocChanged = args.new_date !== expense.associatedDate;
+    if (dateChanged) {
+      ops.push(replaceField([...base, "date"], expense.date, args.new_date));
+    }
+    if (assocChanged) {
+      ops.push(replaceField([...base, "associatedDate"], expense.associatedDate, args.new_date));
+    }
+    if (dateChanged || assocChanged) {
+      changes.push(`date → ${args.new_date}`);
+    }
+  }
+
+  return { ops, changes };
+}
+
+export async function editExpense(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const hasNewValue =
+      args.new_description !== undefined ||
+      args.new_amount !== undefined ||
+      args.new_currency !== undefined ||
+      args.new_category !== undefined ||
+      args.new_date !== undefined;
+    if (!hasNewValue) {
+      throw new WanderlogValidationError(
+        "Nothing to edit — supply at least one of new_description, new_amount, new_currency, new_category, or new_date.",
+      );
+    }
+
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const matches = findExpenseMatches(trip, {
+      description: args.description,
+      date: args.date,
+      amount: args.amount,
+      currency: args.currency,
+    });
+
+    if (matches.length === 0) {
+      throw new WanderlogNotFoundError("Expense", args.description);
+    }
+
+    if (matches.length > 1) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.description}" matches ${matches.length} expenses:\n${formatCandidateList(matches)}\n\nRe-call with a more specific description, or add a date / amount / currency filter to pick one.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { index, expense } = matches[0]!;
+    const { ops, changes } = buildEditOps(expense, index, args);
+
+    if (ops.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `No changes — ${formatExpense(expense)} already has those values.`,
+          },
+        ],
+      };
+    }
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Updated expense ${formatExpense(expense)} in "${trip.title}": ${changes.join(", ")}.`,
+        },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/expenses-shared.ts
+++ b/src/tools/expenses-shared.ts
@@ -1,0 +1,77 @@
+import type { Expense, TripPlan } from "../types.js";
+
+/** A located expense: the live array index plus the expense object itself. */
+export type ExpenseMatch = {
+  index: number;
+  expense: Expense;
+};
+
+/** Filters used to narrow expense matches. All are optional except via the caller. */
+export type ExpenseFilters = {
+  description?: string;
+  date?: string;
+  amount?: number;
+  currency?: string;
+};
+
+/**
+ * Reads `trip.itinerary.budget.expenses`, pairing each expense with its array
+ * index so callers can build JSON0 list paths. Returns an empty array when the
+ * trip has no budget yet.
+ */
+export function getExpenses(trip: TripPlan): ExpenseMatch[] {
+  const expenses = trip.itinerary.budget?.expenses ?? [];
+  return expenses.map((expense, index) => ({ index, expense }));
+}
+
+/**
+ * Finds expenses matching a case-insensitive description substring, optionally
+ * narrowed by exact date, amount, and (case-insensitive) currency filters used
+ * to disambiguate duplicates. An empty/omitted description matches every
+ * expense, so `list_expenses` can call with filters alone.
+ */
+export function findExpenseMatches(
+  trip: TripPlan,
+  filters: ExpenseFilters,
+): ExpenseMatch[] {
+  const description = filters.description?.toLowerCase();
+  const currency = filters.currency?.toUpperCase();
+
+  return getExpenses(trip).filter(({ expense }) => {
+    if (description) {
+      const desc = (expense.description ?? "").toLowerCase();
+      if (!desc.includes(description)) return false;
+    }
+    if (filters.date && expense.date !== filters.date) return false;
+    if (filters.amount !== undefined && expense.amount?.amount !== filters.amount) {
+      return false;
+    }
+    if (currency && (expense.amount?.currencyCode ?? "").toUpperCase() !== currency) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Renders matched expenses as a numbered list for an ambiguity prompt, capped
+ * at `limit` with a "(N more…)" suffix so a huge budget doesn't flood the LLM.
+ */
+export function formatCandidateList(matches: ExpenseMatch[], limit = 10): string {
+  const lines = matches
+    .slice(0, limit)
+    .map((m, i) => `  ${i + 1}. ${formatExpense(m.expense)}`)
+    .join("\n");
+  const suffix = matches.length > limit ? `\n  (${matches.length - limit} more…)` : "";
+  return `${lines}${suffix}`;
+}
+
+/** One-line human label, e.g. `USD 12.50 — Lunch at Ichiran Ramen (food, 2026-05-04)`. */
+export function formatExpense(expense: Expense): string {
+  const currency = expense.amount?.currencyCode ?? "?";
+  const amount = expense.amount?.amount ?? "?";
+  const description = expense.description?.trim() || "(no description)";
+  const meta = [expense.category, expense.date].filter(Boolean).join(", ");
+  const suffix = meta ? ` (${meta})` : "";
+  return `${currency} ${amount} — ${description}${suffix}`;
+}

--- a/src/tools/list-expenses.ts
+++ b/src/tools/list-expenses.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError } from "../errors.js";
+import { findExpenseMatches, formatExpense } from "./expenses-shared.js";
+
+export const listExpensesInputSchema = {
+  trip_key: z.string().min(1).describe("The trip whose expenses to list."),
+  description: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Optional case-insensitive substring to filter by expense description."),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Optional exact date filter, YYYY-MM-DD."),
+  amount: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Optional exact amount filter (e.g. 50, 12.50)."),
+  currency: z
+    .string()
+    .min(3)
+    .max(3)
+    .optional()
+    .describe("Optional ISO 4217 currency filter (e.g. 'USD'). Case-insensitive."),
+};
+
+export const listExpensesDescription = `
+Lists budget expenses on a Wanderlog trip, newest entries last.
+
+Each line shows the amount, currency, description, category, and date. Use the optional
+description / date / amount / currency filters to narrow the list — handy for finding the exact
+expense to pass to wanderlog_remove_expense or wanderlog_edit_expense when several are similar.
+
+Returns a friendly message when the trip has no matching expenses.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  description?: string;
+  date?: string;
+  amount?: number;
+  currency?: string;
+};
+
+export async function listExpenses(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const matches = findExpenseMatches(trip, {
+      description: args.description,
+      date: args.date,
+      amount: args.amount,
+      currency: args.currency,
+    });
+
+    if (matches.length === 0) {
+      const filtered =
+        args.description || args.date || args.amount !== undefined || args.currency;
+      const text = filtered
+        ? `No expenses match those filters in "${trip.title}".`
+        : `No expenses logged in "${trip.title}" yet. Add one with wanderlog_add_expense.`;
+      return { content: [{ type: "text", text }] };
+    }
+
+    const lines = matches.map((m, i) => `  ${i + 1}. ${formatExpense(m.expense)}`).join("\n");
+    const noun = matches.length === 1 ? "expense" : "expenses";
+    return {
+      content: [
+        { type: "text", text: `${matches.length} ${noun} in "${trip.title}":\n${lines}` },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/remove-expense.ts
+++ b/src/tools/remove-expense.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import {
+  findExpenseMatches,
+  formatCandidateList,
+  formatExpense,
+} from "./expenses-shared.js";
+import { submitOp } from "./shared.js";
+
+export const removeExpenseInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to remove the expense from."),
+  description: z
+    .string()
+    .min(1)
+    .describe("Case-insensitive substring matching the expense description to remove."),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Optional exact date filter to disambiguate duplicates, YYYY-MM-DD."),
+  amount: z
+    .number()
+    .positive()
+    .optional()
+    .describe("Optional exact amount filter to disambiguate duplicates."),
+  currency: z
+    .string()
+    .min(3)
+    .max(3)
+    .optional()
+    .describe("Optional ISO 4217 currency filter to disambiguate duplicates. Case-insensitive."),
+};
+
+export const removeExpenseDescription = `
+Removes a budget expense from a Wanderlog trip by matching a substring of its description.
+
+The match is case-insensitive. If exactly one expense matches, it is deleted. If none match, an
+error is returned. If several match, a numbered list is returned and nothing is deleted — re-call
+with a more specific description or add a date / amount / currency filter to pick one.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  description: string;
+  date?: string;
+  amount?: number;
+  currency?: string;
+};
+
+export async function removeExpense(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const matches = findExpenseMatches(trip, {
+      description: args.description,
+      date: args.date,
+      amount: args.amount,
+      currency: args.currency,
+    });
+
+    if (matches.length === 0) {
+      throw new WanderlogNotFoundError("Expense", args.description);
+    }
+
+    if (matches.length > 1) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.description}" matches ${matches.length} expenses:\n${formatCandidateList(matches)}\n\nRe-call with a more specific description, or add a date / amount / currency filter to pick one.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { index, expense } = matches[0]!;
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "budget", "expenses", index],
+        ld: expense,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Removed expense ${formatExpense(expense)} from "${trip.title}".`,
+        },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,6 +148,36 @@ export type Section = {
   placeMarkerIcon?: string;
 };
 
+/** Money sub-object on a budget expense: `{ amount, currencyCode }`. */
+export type ExpenseAmount = {
+  amount: number;
+  currencyCode: string;
+  [k: string]: unknown;
+};
+
+/**
+ * A budget expense at `trip.itinerary.budget.expenses[]`. Only the fields we
+ * read or edit are typed; the index signature preserves the many other fields
+ * Wanderlog attaches (paidByUser, splitWith, blockId, …) so edits don't drop
+ * them.
+ */
+export type Expense = {
+  id: number;
+  amount: ExpenseAmount;
+  category?: string;
+  description?: string;
+  /** Transaction date (YYYY-MM-DD). */
+  date?: string;
+  /** Trip day the expense is grouped under — this is what the budget UI shows. */
+  associatedDate?: string;
+  [k: string]: unknown;
+};
+
+export type Budget = {
+  expenses?: Expense[];
+  [k: string]: unknown;
+};
+
 export type Contributor = {
   id: number;
   username: string;
@@ -185,7 +215,7 @@ export type TripPlan = {
   itinerary: {
     sections: Section[];
     options?: unknown;
-    budget?: unknown;
+    budget?: Budget;
     journal?: unknown;
   };
   schemaVersion: number;

--- a/tests/fixtures/budget-trip.ts
+++ b/tests/fixtures/budget-trip.ts
@@ -1,0 +1,88 @@
+import type { TripPlan } from "../../src/types.ts";
+
+/**
+ * Fixture with a populated `itinerary.budget.expenses` array for testing the
+ * list / remove / edit expense tools. Expenses carry the full Wanderlog shape
+ * (nested `amount`, plus paidByUser / splitWith / blockId) so tests can assert
+ * that edits preserve unknown fields. Two "Ichiran" expenses exercise the
+ * ambiguity path; date / amount / currency differ so filters can disambiguate.
+ */
+export const budgetTrip: TripPlan = {
+  id: 88888888,
+  key: "budgettripkey",
+  title: "Trip to Tokyo",
+  userId: 3656632,
+  privacy: "private",
+  startDate: "2026-06-01",
+  endDate: "2026-06-03",
+  days: 3,
+  placeCount: 1,
+  schemaVersion: 2,
+  createdAt: "2026-05-01T00:00:00Z",
+  updatedAt: "2026-05-15T00:00:00Z",
+  itinerary: {
+    sections: [
+      {
+        id: 100,
+        type: "normal",
+        mode: "placeList",
+        heading: "Places to visit",
+        date: null,
+        blocks: [
+          {
+            id: 50001,
+            type: "place",
+            place: { name: "Sensō-ji", place_id: "ChIJsensoji" },
+          },
+        ],
+      },
+    ],
+    budget: {
+      currencyCode: "USD",
+      expenses: [
+        {
+          id: 90001,
+          amount: { amount: 12.5, currencyCode: "USD" },
+          category: "food",
+          description: "Lunch at Ichiran Ramen",
+          date: "2026-06-01",
+          paidByUserId: 3656632,
+          paidByUser: { type: "registered", id: 3656632 },
+          splitWith: { type: "individuals", users: [] },
+          blockId: 50001,
+          associatedDate: "2026-06-01",
+        },
+        {
+          id: 90002,
+          amount: { amount: 8, currencyCode: "USD" },
+          category: "publicTransit",
+          description: "Subway day pass",
+          date: "2026-06-01",
+          paidByUserId: 3656632,
+          blockId: 50001,
+          associatedDate: "2026-06-01",
+        },
+        {
+          id: 90003,
+          amount: { amount: 2000, currencyCode: "JPY" },
+          category: "food",
+          description: "Dinner at Ichiran Ramen",
+          date: "2026-06-02",
+          paidByUserId: 3656632,
+          blockId: 50001,
+          associatedDate: "2026-06-02",
+        },
+        {
+          id: 90004,
+          amount: { amount: 15, currencyCode: "EUR" },
+          category: "sightseeing",
+          description: "Museum entry",
+          date: "2026-06-03",
+          paidByUserId: 3656632,
+          blockId: 50001,
+          associatedDate: "2026-06-03",
+        },
+      ],
+    },
+  },
+};

--- a/tests/integration/expenses.test.ts
+++ b/tests/integration/expenses.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createContext, type AppContext } from "../../src/context.ts";
+import { createTrip } from "../../src/tools/create-trip.ts";
+import { addExpense } from "../../src/tools/add-expense.ts";
+import { listExpenses } from "../../src/tools/list-expenses.ts";
+import { editExpense } from "../../src/tools/edit-expense.ts";
+import { removeExpense } from "../../src/tools/remove-expense.ts";
+import type { Expense, TripPlan } from "../../src/types.ts";
+
+/**
+ * Live round-trip for the budget-expense tools against the real Wanderlog API.
+ * Creates a throwaway trip, adds an UNLINKED expense (no place required), then
+ * lists / edits / removes it — re-reading the server via REST between steps for
+ * authoritative assertions. Deletes the trip in afterAll.
+ *
+ * A stray trip from a mid-run crash shows up as "WANDERDOG_TEST_<timestamp>".
+ */
+describe("Expense tools (live round-trip)", () => {
+  let ctx: AppContext;
+  let tripKey: string | undefined;
+
+  const expenseByDesc = (trip: TripPlan, desc: string): Expense | undefined =>
+    (trip.itinerary.budget?.expenses ?? []).find((e) => e.description === desc);
+
+  beforeAll(async () => {
+    if (!process.env.WANDERLOG_COOKIE) {
+      throw new Error("WANDERLOG_COOKIE must be set");
+    }
+    ctx = createContext();
+    const user = await ctx.rest.getUser();
+    ctx.userId = user.id;
+  }, 20_000);
+
+  afterAll(async () => {
+    ctx?.pool.closeAll();
+    if (tripKey) {
+      try {
+        await ctx.rest.deleteTrip(tripKey);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  it("creates a throwaway trip", async () => {
+    const result = await createTrip(ctx, {
+      destination: "Tokyo",
+      start_date: "2099-02-01",
+      end_date: "2099-02-03",
+      title: `WANDERDOG_TEST_${Date.now()}`,
+      privacy: "private",
+    });
+    expect(result.isError).not.toBe(true);
+    const keyMatch = /Key: (\w+)/.exec(result.content[0]!.text);
+    expect(keyMatch).not.toBeNull();
+    tripKey = keyMatch![1]!;
+  }, 15_000);
+
+  it("add_expense adds an UNLINKED expense (no place required)", async () => {
+    expect(tripKey).toBeDefined();
+    const res = await addExpense(ctx, {
+      trip_key: tripKey!,
+      amount: 42.5,
+      currency: "usd",
+      category: "food",
+      description: "Ramen lunch",
+    });
+    if (res.isError) throw new Error(`add_expense failed: ${res.content[0]!.text}`);
+    expect(res.content[0]!.text).not.toContain("linked to");
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    const e = expenseByDesc(trip, "Ramen lunch");
+    expect(e).toBeDefined();
+    expect(e!.blockId).toBeNull();
+    expect(e!.amount).toEqual({ amount: 42.5, currencyCode: "USD" });
+    expect(e!.category).toBe("food");
+  }, 30_000);
+
+  it("list_expenses shows the expense", async () => {
+    expect(tripKey).toBeDefined();
+    const res = await listExpenses(ctx, { trip_key: tripKey! });
+    expect(res.isError).not.toBe(true);
+    expect(res.content[0]!.text).toContain("Ramen lunch");
+    expect(res.content[0]!.text).toContain("USD 42.5");
+  }, 15_000);
+
+  it("edit_expense changes amount, currency, category, description (server-confirmed)", async () => {
+    expect(tripKey).toBeDefined();
+    const res = await editExpense(ctx, {
+      trip_key: tripKey!,
+      description: "Ramen lunch",
+      new_amount: 50,
+      new_currency: "jpy",
+      new_category: "drinks",
+      new_description: "Ramen + beer",
+      new_date: "2099-02-02",
+    });
+    if (res.isError) throw new Error(`edit_expense failed: ${res.content[0]!.text}`);
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    const e = expenseByDesc(trip, "Ramen + beer");
+    expect(e).toBeDefined();
+    expect(e!.amount).toEqual({ amount: 50, currencyCode: "JPY" }); // currency uppercased
+    expect(e!.category).toBe("drinks");
+    // new_date updates BOTH fields — the budget UI displays associatedDate.
+    expect(e!.date).toBe("2099-02-02");
+    expect(e!.associatedDate).toBe("2099-02-02");
+    // Unknown fields we never touched must survive the edit.
+    expect(e!.paidByUser).toBeDefined();
+    expect(e!.splitWith).toBeDefined();
+    expect("blockId" in e!).toBe(true);
+  }, 30_000);
+
+  it("edit_expense returns not-found for a non-matching description", async () => {
+    expect(tripKey).toBeDefined();
+    const res = await editExpense(ctx, {
+      trip_key: tripKey!,
+      description: "no_such_expense_xyz",
+      new_amount: 1,
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text.toLowerCase()).toContain("not found");
+  }, 15_000);
+
+  it("remove_expense deletes the expense", async () => {
+    expect(tripKey).toBeDefined();
+    const res = await removeExpense(ctx, { trip_key: tripKey!, description: "Ramen + beer" });
+    if (res.isError) throw new Error(`remove_expense failed: ${res.content[0]!.text}`);
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    expect(expenseByDesc(trip, "Ramen + beer")).toBeUndefined();
+  }, 30_000);
+});

--- a/tests/integration/mcp-smoke.test.ts
+++ b/tests/integration/mcp-smoke.test.ts
@@ -87,7 +87,7 @@ describe("MCP stdio server (smoke)", () => {
     expect(p.pid).toBeDefined();
   });
 
-  it("responds to tools/list with all 18 tools", async () => {
+  it("responds to tools/list with all 21 tools", async () => {
     const p = startServer();
     await waitForReady(p);
     await initialize(p);
@@ -107,11 +107,14 @@ describe("MCP stdio server (smoke)", () => {
       "wanderlog_add_place",
       "wanderlog_annotate_place",
       "wanderlog_create_trip",
+      "wanderlog_edit_expense",
       "wanderlog_edit_note",
       "wanderlog_get_guide",
       "wanderlog_get_trip",
       "wanderlog_get_trip_url",
+      "wanderlog_list_expenses",
       "wanderlog_list_trips",
+      "wanderlog_remove_expense",
       "wanderlog_remove_note",
       "wanderlog_remove_place",
       "wanderlog_rename_day",

--- a/tests/unit/add-expense.test.ts
+++ b/tests/unit/add-expense.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import type { Json0Op } from "../../src/ot/apply.ts";
+import type { TripPlan } from "../../src/types.ts";
+import { addExpense } from "../../src/tools/add-expense.ts";
+import { budgetTrip } from "../fixtures/budget-trip.ts";
+
+function makeFakeContext(trip: TripPlan): { ctx: AppContext; submittedOps: Json0Op[][] } {
+  const submittedOps: Json0Op[][] = [];
+  const ctx = {
+    userId: 555,
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      getEntry: async () => ({ snapshot: structuredClone(trip), version: 1, geos: [] }),
+      get: async () => structuredClone(trip),
+      applyLocalOp: () => {},
+      invalidate: () => {},
+    },
+  } as unknown as AppContext;
+  return { ctx, submittedOps };
+}
+
+const liOf = (ops: Json0Op[][]) => ops[0]![0] as { p: (string | number)[]; li: Record<string, any> };
+
+describe("addExpense — unlinked (no place)", () => {
+  it("adds an expense with blockId null and no place in the message", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const res = await addExpense(ctx, {
+      trip_key: "budgettripkey",
+      amount: 20,
+      currency: "usd",
+      category: "food",
+      description: "Snack",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toContain('Added expense: USD 20 for "Snack"');
+    expect(res.content[0]!.text).not.toContain("linked to");
+
+    const op = liOf(submittedOps);
+    // inserted at the end of the existing 4 expenses
+    expect(op.p).toEqual(["itinerary", "budget", "expenses", 4]);
+    expect(op.li.blockId).toBeNull();
+    expect(op.li.amount).toEqual({ amount: 20, currencyCode: "USD" });
+    expect(op.li.category).toBe("food");
+  });
+});
+
+describe("addExpense — linked (place given)", () => {
+  it("links to the resolved place and reports it", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const res = await addExpense(ctx, {
+      trip_key: "budgettripkey",
+      amount: 9,
+      currency: "usd",
+      category: "sightseeing",
+      description: "Temple entry",
+      place: "Sensō-ji",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toContain("linked to Sensō-ji");
+    const op = liOf(submittedOps);
+    expect(op.li.blockId).toBe(50001); // the Sensō-ji place block id in the fixture
+  });
+
+  it("errors when the place reference matches nothing", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const res = await addExpense(ctx, {
+      trip_key: "budgettripkey",
+      amount: 9,
+      currency: "usd",
+      category: "other",
+      description: "Mystery",
+      place: "no_such_place_xyz",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("No place matching");
+    expect(submittedOps).toHaveLength(0);
+  });
+});

--- a/tests/unit/expenses.test.ts
+++ b/tests/unit/expenses.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import type { TripPlan } from "../../src/types.ts";
+import {
+  findExpenseMatches,
+  formatExpense,
+  getExpenses,
+} from "../../src/tools/expenses-shared.ts";
+import { listExpenses } from "../../src/tools/list-expenses.ts";
+import { removeExpense } from "../../src/tools/remove-expense.ts";
+import { editExpense } from "../../src/tools/edit-expense.ts";
+import { budgetTrip } from "../fixtures/budget-trip.ts";
+
+function fresh(trip: TripPlan): TripPlan {
+  return structuredClone(trip);
+}
+
+function makeFakeContext(trip: TripPlan): {
+  ctx: AppContext;
+  submittedOps: Json0Op[][];
+  invalidateCount: { value: number };
+} {
+  const submittedOps: Json0Op[][] = [];
+  const invalidateCount = { value: 0 };
+
+  const ctx = {
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      get: async () => structuredClone(trip),
+      applyLocalOp: () => {},
+      invalidate: () => {
+        invalidateCount.value++;
+      },
+    },
+  } as unknown as AppContext;
+
+  return { ctx, submittedOps, invalidateCount };
+}
+
+// ---------------------------------------------------------------------------
+// getExpenses / formatExpense
+// ---------------------------------------------------------------------------
+
+describe("getExpenses", () => {
+  it("returns indexed expenses from the budget", () => {
+    const result = getExpenses(fresh(budgetTrip));
+    expect(result).toHaveLength(4);
+    expect(result[0]!.index).toBe(0);
+    expect(result[0]!.expense.description).toBe("Lunch at Ichiran Ramen");
+  });
+
+  it("returns an empty array when the trip has no budget", () => {
+    const trip = fresh(budgetTrip);
+    delete (trip.itinerary as { budget?: unknown }).budget;
+    expect(getExpenses(trip)).toHaveLength(0);
+  });
+});
+
+describe("formatExpense", () => {
+  it("renders amount, currency, description, category and date", () => {
+    const expense = fresh(budgetTrip).itinerary.budget!.expenses![0]!;
+    expect(formatExpense(expense)).toBe("USD 12.5 — Lunch at Ichiran Ramen (food, 2026-06-01)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findExpenseMatches
+// ---------------------------------------------------------------------------
+
+describe("findExpenseMatches", () => {
+  it("matches a description substring case-insensitively", () => {
+    const matches = findExpenseMatches(fresh(budgetTrip), { description: "SUBWAY" });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.expense.description).toBe("Subway day pass");
+  });
+
+  it("returns no matches for an unknown description", () => {
+    expect(findExpenseMatches(fresh(budgetTrip), { description: "nope_nothing" })).toHaveLength(0);
+  });
+
+  it("returns multiple matches for a shared substring", () => {
+    const matches = findExpenseMatches(fresh(budgetTrip), { description: "ichiran" });
+    expect(matches).toHaveLength(2);
+  });
+
+  it("narrows duplicates with a date filter", () => {
+    const matches = findExpenseMatches(fresh(budgetTrip), {
+      description: "ichiran",
+      date: "2026-06-02",
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.expense.description).toBe("Dinner at Ichiran Ramen");
+  });
+
+  it("narrows duplicates with an amount filter", () => {
+    const matches = findExpenseMatches(fresh(budgetTrip), { description: "ichiran", amount: 12.5 });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.expense.date).toBe("2026-06-01");
+  });
+
+  it("narrows duplicates with a case-insensitive currency filter", () => {
+    const matches = findExpenseMatches(fresh(budgetTrip), { description: "ichiran", currency: "jpy" });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]!.expense.amount.currencyCode).toBe("JPY");
+  });
+
+  it("matches everything when no description is given", () => {
+    expect(findExpenseMatches(fresh(budgetTrip), {})).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listExpenses
+// ---------------------------------------------------------------------------
+
+describe("listExpenses", () => {
+  it("lists all expenses with a count header", async () => {
+    const { ctx } = makeFakeContext(budgetTrip);
+    const result = await listExpenses(ctx, { trip_key: "budgettripkey" });
+    expect(result.isError).toBeUndefined();
+    const text = result.content[0]!.text;
+    expect(text).toContain("4 expenses");
+    expect(text).toContain("Lunch at Ichiran Ramen");
+    expect(text).toContain("Museum entry");
+  });
+
+  it("applies filters to the listing", async () => {
+    const { ctx } = makeFakeContext(budgetTrip);
+    const result = await listExpenses(ctx, { trip_key: "budgettripkey", currency: "EUR" });
+    const text = result.content[0]!.text;
+    expect(text).toContain("1 expense");
+    expect(text).toContain("Museum entry");
+    expect(text).not.toContain("Subway");
+  });
+
+  it("returns a friendly message when there are no expenses", async () => {
+    const trip = fresh(budgetTrip);
+    trip.itinerary.budget!.expenses = [];
+    const { ctx } = makeFakeContext(trip);
+    const result = await listExpenses(ctx, { trip_key: "budgettripkey" });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("No expenses logged");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeExpense
+// ---------------------------------------------------------------------------
+
+describe("removeExpense", () => {
+  it("returns not-found when nothing matches", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await removeExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "nope_nothing",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("returns a candidate list and does not mutate when ambiguous", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await removeExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "ichiran",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("matches 2 expenses");
+    expect(result.content[0]!.text).toContain("Lunch at Ichiran Ramen");
+    expect(result.content[0]!.text).toContain("Dinner at Ichiran Ramen");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("deletes the matched expense with a JSON0 ld op carrying the full object", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await removeExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("Removed expense");
+    expect(submittedOps).toHaveLength(1);
+    const op = submittedOps[0]![0] as { p: (string | number)[]; ld: { id: number } };
+    expect(op.p).toEqual(["itinerary", "budget", "expenses", 1]);
+    expect(op.ld.id).toBe(90002);
+  });
+
+  it("disambiguates via a filter, then deletes the right one", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await removeExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "ichiran",
+      currency: "JPY",
+    });
+    expect(result.isError).toBeUndefined();
+    const op = submittedOps[0]![0] as { p: (string | number)[]; ld: { id: number } };
+    expect(op.p).toEqual(["itinerary", "budget", "expenses", 2]);
+    expect(op.ld.id).toBe(90003);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// editExpense
+// ---------------------------------------------------------------------------
+
+describe("editExpense", () => {
+  it("rejects when no new_* value is supplied", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await editExpense(ctx, { trip_key: "budgettripkey", description: "subway" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Nothing to edit");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("returns not-found when nothing matches", async () => {
+    const { ctx } = makeFakeContext(budgetTrip);
+    const result = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "nope_nothing",
+      new_amount: 5,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not found");
+  });
+
+  it("returns a candidate list and does not mutate when ambiguous", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "ichiran",
+      new_amount: 20,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("matches 2 expenses");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("edits the description with an od+oi op for only that field", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_description: "Metro 72h pass",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(submittedOps).toHaveLength(1);
+    expect(submittedOps[0]).toHaveLength(1);
+    expect(submittedOps[0]![0]).toEqual({
+      p: ["itinerary", "budget", "expenses", 1, "description"],
+      od: "Subway day pass",
+      oi: "Metro 72h pass",
+    });
+  });
+
+  it("edits amount and currency via the nested amount path", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_amount: 9.5,
+      new_currency: "eur",
+    });
+    expect(result.isError).toBeUndefined();
+    const ops = submittedOps[0]!;
+    expect(ops).toContainEqual({
+      p: ["itinerary", "budget", "expenses", 1, "amount", "amount"],
+      od: 8,
+      oi: 9.5,
+    });
+    // currency normalized to uppercase
+    expect(ops).toContainEqual({
+      p: ["itinerary", "budget", "expenses", 1, "amount", "currencyCode"],
+      od: "USD",
+      oi: "EUR",
+    });
+  });
+
+  it("edits the category", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_category: "carRental",
+    });
+    expect(submittedOps[0]![0]).toEqual({
+      p: ["itinerary", "budget", "expenses", 1, "category"],
+      od: "publicTransit",
+      oi: "carRental",
+    });
+  });
+
+  it("edits the date, updating both date and associatedDate", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const res = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_date: "2026-06-09",
+    });
+    expect(res.isError).toBeUndefined();
+    const ops = submittedOps[0]!;
+    expect(ops).toContainEqual({
+      p: ["itinerary", "budget", "expenses", 1, "date"],
+      od: "2026-06-01",
+      oi: "2026-06-09",
+    });
+    expect(ops).toContainEqual({
+      p: ["itinerary", "budget", "expenses", 1, "associatedDate"],
+      od: "2026-06-01",
+      oi: "2026-06-09",
+    });
+  });
+
+  it("syncs associatedDate even when the date field already matches (UI shows associatedDate)", async () => {
+    const trip = fresh(budgetTrip);
+    // Real-world mismatch: date is correct but associatedDate is a day ahead.
+    trip.itinerary.budget!.expenses![1]!.associatedDate = "2026-06-02";
+    const { ctx, submittedOps } = makeFakeContext(trip);
+    const res = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_date: "2026-06-01", // already the `date` value
+    });
+    expect(res.isError).toBeUndefined();
+    const ops = submittedOps[0]!;
+    expect(ops).toHaveLength(1); // only associatedDate needs changing
+    expect(ops[0]).toEqual({
+      p: ["itinerary", "budget", "expenses", 1, "associatedDate"],
+      od: "2026-06-02",
+      oi: "2026-06-01",
+    });
+  });
+
+  it("only emits ops for fields that actually change", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_amount: 8, // unchanged
+      new_currency: "USD", // unchanged
+      new_description: "Subway 1-day pass", // changed
+    });
+    const ops = submittedOps[0]!;
+    expect(ops).toHaveLength(1);
+    expect((ops[0] as { p: (string | number)[] }).p).toEqual([
+      "itinerary",
+      "budget",
+      "expenses",
+      1,
+      "description",
+    ]);
+  });
+
+  it("returns a no-change message when nothing differs", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    const result = await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_amount: 8,
+      new_currency: "usd",
+    });
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("No changes");
+    expect(submittedOps).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: the produced ops must apply cleanly via the real applyOp, the
+// same path submitOp → tripCache.applyLocalOp uses. Catches bad JSON0 paths
+// the fake submit would otherwise mask, and proves unknown fields survive.
+// ---------------------------------------------------------------------------
+
+describe("expense ops apply via applyOp", () => {
+  it("remove deletes only the matched expense", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    await removeExpense(ctx, { trip_key: "budgettripkey", description: "subway" });
+    const next = applyOp(fresh(budgetTrip), submittedOps[0]!);
+    const descriptions = next.itinerary.budget!.expenses!.map((e) => e.description);
+    expect(descriptions).toEqual([
+      "Lunch at Ichiran Ramen",
+      "Dinner at Ichiran Ramen",
+      "Museum entry",
+    ]);
+  });
+
+  it("edit changes the targeted fields and preserves unknown ones", async () => {
+    const { ctx, submittedOps } = makeFakeContext(budgetTrip);
+    await editExpense(ctx, {
+      trip_key: "budgettripkey",
+      description: "subway",
+      new_amount: 9.5,
+      new_currency: "eur",
+      new_description: "Metro pass",
+      new_category: "carRental",
+    });
+    const next = applyOp(fresh(budgetTrip), submittedOps[0]!);
+    const edited = next.itinerary.budget!.expenses![1]!;
+    expect(edited.description).toBe("Metro pass");
+    expect(edited.category).toBe("carRental");
+    expect(edited.amount).toEqual({ amount: 9.5, currencyCode: "EUR" });
+    // Fields we never touched are still intact.
+    expect(edited.id).toBe(90002);
+    expect(edited.blockId).toBe(50001);
+    expect(edited.paidByUserId).toBe(3656632);
+    expect(edited.associatedDate).toBe("2026-06-01");
+  });
+});


### PR DESCRIPTION
## Summary

Adds three MCP tools for managing a trip's budget expenses (`trip.itinerary.budget.expenses`): `wanderlog_list_expenses`, `wanderlog_remove_expense`, and `wanderlog_edit_expense`. They use a case-insensitive description substring as the human-friendly selector, with optional `date` / `amount` / `currency` filters to disambiguate duplicates — zero matches return a friendly not-found error, and multiple matches return a numbered candidate list without mutating the trip.

`remove` deletes the matched item with a JSON0 `ld`; `edit` submits `od`+`oi` only for the fields that changed (description, amount, currency, category, date), preserving any unknown Wanderlog fields rather than rebuilding the expense. Currency is normalized to uppercase. Two small related changes fell out of live testing:

- **`add_expense`: `place` is now optional.** Wanderlog accepts unlinked expenses (`blockId: null`) — real UI-created expenses prove it — so the hard place requirement (and its stale "the UI crashes on unlinked expenses" comment) is removed. Pass `place` to link, omit it for a standalone expense.
- **`edit_expense`'s `new_date` updates both `date` and `associatedDate`.** The budget list UI displays `associatedDate` (the trip day the expense is grouped under), not `date`; syncing both is required for the shown date to actually change.

Reusable `Expense` / `ExpenseAmount` / `Budget` types and shared helpers (`getExpenses`, `findExpenseMatches`, `formatExpense`) back the new tools.

## Test plan

- `npm run typecheck`, `npm run build`, and `npm run test` all pass — 295 unit tests, including new coverage for matching, filter disambiguation, ambiguity handling (no mutation), list output, deletion, per-field edits, currency uppercasing, the `date`/`associatedDate` sync, and end-to-end application of the generated ops through the real `applyOp`. Linked + unlinked `add_expense` paths are covered too.
- New gated live integration test (`tests/integration/expenses.test.ts`): creates a throwaway trip, adds an unlinked expense, then lists / edits / removes it, re-reading the server over REST between steps to confirm server-side state (money nesting, uppercased currency, category, `date` + `associatedDate`, and that unknown fields survive the edit). It auto-deletes the trip. Verified green against the live Wanderlog API via `npm run test:integration` scoped to this file.
- Manually exercised every tool against a real trip end-to-end (add unlinked → list → edit amount/currency/category/date → remove) and confirmed the results render correctly in the Wanderlog web budget view — this is what surfaced the `associatedDate` display detail.

## Agent-facing surface changes

- [x] Changed a tool description, parameter doc, or error message
      (new descriptions/params for list/remove/edit_expense and a relaxed
      `add_expense` description/param — reviewed for injection risk and clarity)
