### PR TITLE
feat: add journal (travelogue) tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ and a ryokan in Shinjuku."
 | `wanderlog_remove_place` | Remove a place by natural-language reference |
 | `wanderlog_update_trip_dates` | Change a trip's date range |
 | `wanderlog_rename_day` | Rename a day's heading (e.g. `"Barcelona"` → `"Arrival — Feria de Abril"`) |
+| `wanderlog_list_journal` | List journal (travelogue) stops, optionally filtered by title or date |
+| `wanderlog_add_journal` | Add a journal stop: a place + date/time + text entry |
+| `wanderlog_edit_journal` | Edit a journal stop's title, text, or date/time (or the journal summary) |
+| `wanderlog_remove_journal` | Remove a journal stop by title (with an optional date filter) |
 
 ## Prerequisites
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -184,6 +184,18 @@ Example add_place call with all features:
     start_time: "08:30", end_time: "10:00")
 
 Places without notes and times are just pins on a map. Rich places make an itinerary useful.
+
+JOURNALING (a trip's travelogue of places the user actually visited):
+  wanderlog_list_journal / add_journal / edit_journal / remove_journal manage the journal.
+  A journal stop is a place + date/time + a text entry (the user's notes about visiting it).
+  - wanderlog_add_journal first REUSES a place already in the trip (an itinerary place or an
+    existing journal stop) and dates the new stop to the day that place is scheduled on.
+  - If the place is NOT in the trip yet, add_journal does NOT add it silently — it returns a
+    prompt. ASK the user whether to add it to their itinerary first (wanderlog_add_place, on the
+    right day) or to journal it as a new place with allow_new_place: true. Don't pass
+    allow_new_place on the user's behalf without asking.
+  - Select a stop to edit/remove by a substring of its title (matching ignores case and accents).
+    wanderlog_edit_journal can also set the trip-level journal summary via new_summary.
 `.trim();
 
 export function buildServer(ctx: AppContext): McpServer {

--- a/src/server.ts
+++ b/src/server.ts
@@ -110,6 +110,26 @@ import {
   getGuideDescription,
   getGuideInputSchema,
 } from "./tools/get-guide.js";
+import {
+  listJournal,
+  listJournalDescription,
+  listJournalInputSchema,
+} from "./tools/list-journal.js";
+import {
+  addJournal,
+  addJournalDescription,
+  addJournalInputSchema,
+} from "./tools/add-journal.js";
+import {
+  editJournal,
+  editJournalDescription,
+  editJournalInputSchema,
+} from "./tools/edit-journal.js";
+import {
+  removeJournal,
+  removeJournalDescription,
+  removeJournalInputSchema,
+} from "./tools/remove-journal.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -402,6 +422,50 @@ export function buildServer(ctx: AppContext): McpServer {
     },
     requireAuth(ctx, async (args) =>
       renameDay(ctx, args as Parameters<typeof renameDay>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_list_journal",
+    {
+      title: "List journal stops in a Wanderlog trip",
+      description: listJournalDescription,
+      inputSchema: listJournalInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      listJournal(ctx, args as Parameters<typeof listJournal>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_add_journal",
+    {
+      title: "Add a journal stop to a Wanderlog trip",
+      description: addJournalDescription,
+      inputSchema: addJournalInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      addJournal(ctx, args as Parameters<typeof addJournal>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_edit_journal",
+    {
+      title: "Edit a journal stop or summary in a Wanderlog trip",
+      description: editJournalDescription,
+      inputSchema: editJournalInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      editJournal(ctx, args as Parameters<typeof editJournal>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_remove_journal",
+    {
+      title: "Remove a journal stop from a Wanderlog trip",
+      description: removeJournalDescription,
+      inputSchema: removeJournalInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      removeJournal(ctx, args as Parameters<typeof removeJournal>[1])),
   );
 
   return server;

--- a/src/tools/add-journal.ts
+++ b/src/tools/add-journal.ts
@@ -4,7 +4,7 @@ import { WanderlogError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import type { JournalStop, PlaceData } from "../types.js";
 import { findTripCenter, generateBlockId, submitOp } from "./shared.js";
-import { findTripPlaces, getJournalStops } from "./journal-shared.js";
+import { findTripPlaces, getJournalStops, placeItineraryDate } from "./journal-shared.js";
 
 export const addJournalInputSchema = {
   trip_key: z.string().min(1).describe("The trip to add the journal stop to."),
@@ -148,7 +148,9 @@ export async function addJournal(
     }
 
     const stops = getJournalStops(trip).map((m) => m.stop);
-    const date = args.date ?? new Date().toISOString().slice(0, 10);
+    // Default to the day this place is scheduled on in the itinerary, else today.
+    const date =
+      args.date ?? placeItineraryDate(trip, place) ?? new Date().toISOString().slice(0, 10);
     const time = args.time ?? "09:00";
     const dateTime = `${date}T${time}${existingStopOffset(stops)}`;
 

--- a/src/tools/add-journal.ts
+++ b/src/tools/add-journal.ts
@@ -4,7 +4,7 @@ import { WanderlogError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import type { JournalStop, PlaceData } from "../types.js";
 import { findTripCenter, generateBlockId, submitOp } from "./shared.js";
-import { getJournalStops } from "./journal-shared.js";
+import { findTripPlaces, getJournalStops } from "./journal-shared.js";
 
 export const addJournalInputSchema = {
   trip_key: z.string().min(1).describe("The trip to add the journal stop to."),
@@ -12,13 +12,13 @@ export const addJournalInputSchema = {
     .string()
     .min(1)
     .describe(
-      "Natural-language place this journal stop is about (e.g. 'Marina Bay Sands', 'the ramen place in Hakata'). Resolved against Wanderlog's place search near the trip and embedded in the stop.",
+      "The place this journal stop is about (e.g. 'Marina Bay Sands', 'Gardens by the Bay'). Reuses a matching place already in the trip; if none matches, you'll be prompted to add it to the itinerary first (or pass allow_new_place).",
     ),
   title: z
     .string()
     .min(1)
     .optional()
-    .describe("Title for the stop. Defaults to the resolved place name."),
+    .describe("Title for the stop. Defaults to the place name."),
   text: z
     .string()
     .optional()
@@ -33,15 +33,22 @@ export const addJournalInputSchema = {
     .regex(/^\d{2}:\d{2}$/, "must be HH:mm")
     .optional()
     .describe("Time of the stop, HH:mm. Defaults to 09:00."),
+  allow_new_place: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set true to journal a place that isn't in your itinerary — it's searched and added as a new (unplanned) place. Leave unset to be prompted instead.",
+    ),
 };
 
 export const addJournalDescription = `
 Adds a stop to a Wanderlog trip's journal (travelogue). A stop pins a place with a date/time and
 an optional text entry, and appears in the trip's journal timeline.
 
-The place is resolved against Wanderlog's place search near the trip's destination — pass a
-natural-language name and the best match is embedded in the stop. Returns confirmation with the
-resolved place name.
+Place handling: the tool first reuses a place already in the trip (an itinerary place or an
+existing journal stop) that matches the name. If the place isn't in the trip yet, it does NOT
+add it silently — it returns a prompt suggesting you add it to the itinerary first
+(wanderlog_add_place), or re-call with allow_new_place: true to journal it as a new place.
 `.trim();
 
 type Args = {
@@ -51,6 +58,7 @@ type Args = {
   text?: string;
   date?: string;
   time?: string;
+  allow_new_place?: boolean;
 };
 
 /**
@@ -59,10 +67,6 @@ type Args = {
  * existing stop on the trip; absent that, send a bare local datetime and let
  * the server attach the offset (verified against live data).
  */
-function buildDateTime(date: string, time: string, existingOffset: string): string {
-  return `${date}T${time}${existingOffset}`;
-}
-
 function existingStopOffset(stops: JournalStop[]): string {
   for (const s of stops) {
     const m = typeof s.dateTime === "string" ? /([+-]\d{2}:\d{2})$/.exec(s.dateTime) : null;
@@ -79,68 +83,105 @@ export async function addJournal(
     const entry = await ctx.tripCache.getEntry(args.trip_key);
     const trip = entry.snapshot;
 
-    const center = findTripCenter(trip, entry.geos);
-    if (!center) {
-      throw new WanderlogError(
-        `Cannot resolve a place for the journal stop in "${trip.title}"`,
-        "no_location_anchor",
-        "This trip has no associated geo and no existing places. Add a place to the trip first.",
-      );
+    // Tier 1: reuse a place the trip already references (itinerary or journal).
+    const existing = findTripPlaces(trip, args.place);
+    let place: PlaceData;
+    let linkedToTrip: boolean;
+
+    if (existing.length > 1) {
+      const lines = existing.slice(0, 10).map((p, i) => `  ${i + 1}. ${p.name}`).join("\n");
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.place}" matches ${existing.length} places already in "${trip.title}":\n${lines}\n\nRe-call with a more specific name.`,
+          },
+        ],
+        isError: true,
+      };
     }
 
-    const predictions = await ctx.rest.searchPlacesAutocomplete({
-      input: args.place,
-      sessionToken: crypto.randomUUID(),
-      location: { latitude: center.lat, longitude: center.lng },
-      radius: 15000,
-    });
-    if (predictions.length === 0) {
-      throw new WanderlogError(
-        `No place found matching "${args.place}" near ${trip.title}`,
-        "place_not_found",
-        {
-          hint: "Try a more specific name, or widen the search with wanderlog_search_places first.",
-          followUps: [
-            `Call wanderlog_search_places with trip_key "${args.trip_key}" and a broader query to see candidates.`,
-          ],
-        },
-      );
+    if (existing.length === 1) {
+      place = existing[0]!;
+      linkedToTrip = true;
+    } else if (!args.allow_new_place) {
+      // Tier 2: not in the trip — prompt rather than silently adding a new place.
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.place}" isn't a place in "${trip.title}" yet. Add it to the trip first with wanderlog_add_place and then journal it, or re-call wanderlog_add_journal with allow_new_place: true to add it as a new (unplanned) journal place.`,
+          },
+        ],
+        isError: true,
+      };
+    } else {
+      // Override: search for the place and embed a fresh result.
+      const center = findTripCenter(trip, entry.geos);
+      if (!center) {
+        throw new WanderlogError(
+          `Cannot resolve a new place for the journal stop in "${trip.title}"`,
+          "no_location_anchor",
+          "This trip has no associated geo and no existing places to anchor the search. Add a place to the trip first.",
+        );
+      }
+      const predictions = await ctx.rest.searchPlacesAutocomplete({
+        input: args.place,
+        sessionToken: crypto.randomUUID(),
+        location: { latitude: center.lat, longitude: center.lng },
+        radius: 15000,
+      });
+      if (predictions.length === 0) {
+        throw new WanderlogError(
+          `No place found matching "${args.place}" near ${trip.title}`,
+          "place_not_found",
+          {
+            hint: "Try a more specific name, or widen the search with wanderlog_search_places first.",
+            followUps: [
+              `Call wanderlog_search_places with trip_key "${args.trip_key}" and a broader query to see candidates.`,
+            ],
+          },
+        );
+      }
+      place = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
+      linkedToTrip = false;
     }
-    const detail: PlaceData = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
 
     const stops = getJournalStops(trip).map((m) => m.stop);
     const date = args.date ?? new Date().toISOString().slice(0, 10);
     const time = args.time ?? "09:00";
-    const dateTime = buildDateTime(date, time, existingStopOffset(stops));
+    const dateTime = `${date}T${time}${existingStopOffset(stops)}`;
 
     const stop: Record<string, unknown> = {
       id: generateBlockId(),
       type: "confirmed",
-      title: args.title ?? detail.name,
+      title: args.title ?? place.name,
       dateTime,
-      place: detail,
+      place,
       media: [],
     };
     if (args.text) {
       stop.text = { ops: [{ insert: args.text }] };
     }
 
-    const insertIndex = stops.length;
     const ops: Json0Op[] = [
       {
-        p: ["itinerary", "journal", "stops", insertIndex],
+        p: ["itinerary", "journal", "stops", stops.length],
         li: stop,
       },
     ];
 
     await submitOp(ctx, args.trip_key, ops);
 
-    const titleLabel = (args.title ?? detail.name) || detail.name;
+    const titleLabel = args.title ?? place.name;
+    const suffix = linkedToTrip
+      ? " (reused a place already in your trip)"
+      : ` (new place — ${place.name} wasn't in your itinerary)`;
     return {
       content: [
         {
           type: "text",
-          text: `Added journal stop "${titleLabel}" (${date}) at ${detail.name} in "${trip.title}".`,
+          text: `Added journal stop "${titleLabel}" (${date}) at ${place.name} in "${trip.title}"${suffix}.`,
         },
       ],
     };

--- a/src/tools/add-journal.ts
+++ b/src/tools/add-journal.ts
@@ -1,0 +1,154 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import type { JournalStop, PlaceData } from "../types.js";
+import { findTripCenter, generateBlockId, submitOp } from "./shared.js";
+import { getJournalStops } from "./journal-shared.js";
+
+export const addJournalInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to add the journal stop to."),
+  place: z
+    .string()
+    .min(1)
+    .describe(
+      "Natural-language place this journal stop is about (e.g. 'Marina Bay Sands', 'the ramen place in Hakata'). Resolved against Wanderlog's place search near the trip and embedded in the stop.",
+    ),
+  title: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Title for the stop. Defaults to the resolved place name."),
+  text: z
+    .string()
+    .optional()
+    .describe("The journal entry text for this stop (your notes/story about the place)."),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Date of the stop, YYYY-MM-DD. Defaults to today."),
+  time: z
+    .string()
+    .regex(/^\d{2}:\d{2}$/, "must be HH:mm")
+    .optional()
+    .describe("Time of the stop, HH:mm. Defaults to 09:00."),
+};
+
+export const addJournalDescription = `
+Adds a stop to a Wanderlog trip's journal (travelogue). A stop pins a place with a date/time and
+an optional text entry, and appears in the trip's journal timeline.
+
+The place is resolved against Wanderlog's place search near the trip's destination — pass a
+natural-language name and the best match is embedded in the stop. Returns confirmation with the
+resolved place name.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  place: string;
+  title?: string;
+  text?: string;
+  date?: string;
+  time?: string;
+};
+
+/**
+ * Wanderlog stores each stop's dateTime with a destination timezone offset
+ * (e.g. "+08:00"). We don't carry a tz database, so reuse the offset from an
+ * existing stop on the trip; absent that, send a bare local datetime and let
+ * the server attach the offset (verified against live data).
+ */
+function buildDateTime(date: string, time: string, existingOffset: string): string {
+  return `${date}T${time}${existingOffset}`;
+}
+
+function existingStopOffset(stops: JournalStop[]): string {
+  for (const s of stops) {
+    const m = typeof s.dateTime === "string" ? /([+-]\d{2}:\d{2})$/.exec(s.dateTime) : null;
+    if (m) return m[1]!;
+  }
+  return "";
+}
+
+export async function addJournal(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    const center = findTripCenter(trip, entry.geos);
+    if (!center) {
+      throw new WanderlogError(
+        `Cannot resolve a place for the journal stop in "${trip.title}"`,
+        "no_location_anchor",
+        "This trip has no associated geo and no existing places. Add a place to the trip first.",
+      );
+    }
+
+    const predictions = await ctx.rest.searchPlacesAutocomplete({
+      input: args.place,
+      sessionToken: crypto.randomUUID(),
+      location: { latitude: center.lat, longitude: center.lng },
+      radius: 15000,
+    });
+    if (predictions.length === 0) {
+      throw new WanderlogError(
+        `No place found matching "${args.place}" near ${trip.title}`,
+        "place_not_found",
+        {
+          hint: "Try a more specific name, or widen the search with wanderlog_search_places first.",
+          followUps: [
+            `Call wanderlog_search_places with trip_key "${args.trip_key}" and a broader query to see candidates.`,
+          ],
+        },
+      );
+    }
+    const detail: PlaceData = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
+
+    const stops = getJournalStops(trip).map((m) => m.stop);
+    const date = args.date ?? new Date().toISOString().slice(0, 10);
+    const time = args.time ?? "09:00";
+    const dateTime = buildDateTime(date, time, existingStopOffset(stops));
+
+    const stop: Record<string, unknown> = {
+      id: generateBlockId(),
+      type: "confirmed",
+      title: args.title ?? detail.name,
+      dateTime,
+      place: detail,
+      media: [],
+    };
+    if (args.text) {
+      stop.text = { ops: [{ insert: args.text }] };
+    }
+
+    const insertIndex = stops.length;
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "journal", "stops", insertIndex],
+        li: stop,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const titleLabel = (args.title ?? detail.name) || detail.name;
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Added journal stop "${titleLabel}" (${date}) at ${detail.name} in "${trip.title}".`,
+        },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/edit-journal.ts
+++ b/src/tools/edit-journal.ts
@@ -1,0 +1,199 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError, WanderlogValidationError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import type { JournalStop } from "../types.js";
+import { findStopMatches, formatStop, formatStopCandidateList } from "./journal-shared.js";
+import { submitOp } from "./shared.js";
+
+export const editJournalInputSchema = {
+  trip_key: z.string().min(1).describe("The trip whose journal to edit."),
+  title: z
+    .string()
+    .min(1)
+    .optional()
+    .describe(
+      "Case-insensitive substring matching the title of the stop to edit. Required unless you are only setting new_summary.",
+    ),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Optional exact date filter to disambiguate which stop to edit."),
+  new_title: z.string().min(1).optional().describe("New stop title. Omit to leave unchanged."),
+  new_text: z
+    .string()
+    .optional()
+    .describe("New journal entry text for the stop (replaces the existing text). Omit to leave unchanged."),
+  new_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("New date for the stop, YYYY-MM-DD. Omit to leave unchanged."),
+  new_time: z
+    .string()
+    .regex(/^\d{2}:\d{2}$/, "must be HH:mm")
+    .optional()
+    .describe("New time for the stop, HH:mm. Omit to leave unchanged."),
+  new_summary: z
+    .string()
+    .optional()
+    .describe(
+      "New trip-level journal summary text (the overview shown above the stops). Edits the journal as a whole, not a stop — does not require a title.",
+    ),
+};
+
+export const editJournalDescription = `
+Edits a Wanderlog trip's journal. Usually you edit a single stop: find it by a case-insensitive
+substring of its title, then change its title, text, date, and/or time. You can also set the
+trip-level journal summary via new_summary (which doesn't require a stop title).
+
+If none match, an error is returned. If several stops match, a numbered list is returned and
+nothing is changed. Only the fields you supply are modified; the stop's place, media, and unknown
+fields are preserved.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  title?: string;
+  date?: string;
+  new_title?: string;
+  new_text?: string;
+  new_date?: string;
+  new_time?: string;
+  new_summary?: string;
+};
+
+/** od+oi replacement for an existing key; oi-only insert when the key is absent. */
+function replaceField(path: (string | number)[], oldValue: unknown, newValue: unknown): Json0Op {
+  return oldValue === undefined ? { p: path, oi: newValue } : { p: path, od: oldValue, oi: newValue };
+}
+
+/** Rebuilds a stop's dateTime from new date/time parts, preserving the timezone offset. */
+function rebuildDateTime(current: string | undefined, newDate?: string, newTime?: string): string {
+  const cur = current ?? "";
+  const offset = /([+-]\d{2}:\d{2})$/.exec(cur)?.[1] ?? "";
+  const date = newDate ?? (cur.slice(0, 10) || new Date().toISOString().slice(0, 10));
+  const time = newTime ?? (cur.slice(11, 16) || "09:00");
+  return `${date}T${time}${offset}`;
+}
+
+function buildStopOps(
+  stop: JournalStop,
+  index: number,
+  args: Args,
+): { ops: Json0Op[]; changes: string[] } {
+  const base = ["itinerary", "journal", "stops", index];
+  const ops: Json0Op[] = [];
+  const changes: string[] = [];
+
+  if (args.new_title !== undefined && args.new_title !== stop.title) {
+    ops.push(replaceField([...base, "title"], stop.title, args.new_title));
+    changes.push(`title → "${args.new_title}"`);
+  }
+
+  if (args.new_text !== undefined) {
+    const newDelta = { ops: [{ insert: args.new_text }] };
+    if (JSON.stringify(newDelta) !== JSON.stringify(stop.text)) {
+      ops.push(replaceField([...base, "text"], stop.text, newDelta));
+      changes.push("text");
+    }
+  }
+
+  if (args.new_date !== undefined || args.new_time !== undefined) {
+    const next = rebuildDateTime(stop.dateTime, args.new_date, args.new_time);
+    if (next !== stop.dateTime) {
+      ops.push(replaceField([...base, "dateTime"], stop.dateTime, next));
+      changes.push(`when → ${next.replace("T", " ").slice(0, 16)}`);
+    }
+  }
+
+  return { ops, changes };
+}
+
+export async function editJournal(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const hasStopEdit =
+      args.new_title !== undefined ||
+      args.new_text !== undefined ||
+      args.new_date !== undefined ||
+      args.new_time !== undefined;
+    const hasSummaryEdit = args.new_summary !== undefined;
+
+    if (!hasStopEdit && !hasSummaryEdit) {
+      throw new WanderlogValidationError(
+        "Nothing to edit — supply at least one of new_title, new_text, new_date, new_time, or new_summary.",
+      );
+    }
+
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const ops: Json0Op[] = [];
+    const changes: string[] = [];
+    let stopLabel = "";
+
+    if (hasStopEdit) {
+      if (!args.title) {
+        throw new WanderlogValidationError(
+          "Provide 'title' to identify which journal stop to edit.",
+        );
+      }
+      const matches = findStopMatches(trip, { title: args.title, date: args.date });
+      if (matches.length === 0) {
+        throw new WanderlogNotFoundError("Journal stop", args.title);
+      }
+      if (matches.length > 1) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `"${args.title}" matches ${matches.length} journal stops:\n${formatStopCandidateList(matches)}\n\nRe-call with a more specific title, or add a date filter to pick one.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+      const { index, stop } = matches[0]!;
+      stopLabel = formatStop(stop);
+      const built = buildStopOps(stop, index, args);
+      ops.push(...built.ops);
+      changes.push(...built.changes);
+    }
+
+    if (hasSummaryEdit) {
+      const current = trip.itinerary.journal?.summary;
+      if (args.new_summary !== current) {
+        ops.push(replaceField(["itinerary", "journal", "summary"], current, args.new_summary));
+        changes.push("journal summary");
+      }
+    }
+
+    if (ops.length === 0) {
+      return {
+        content: [
+          { type: "text", text: `No changes — those values already match in "${trip.title}".` },
+        ],
+      };
+    }
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const target = stopLabel ? `stop ${stopLabel}` : "journal";
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Updated ${target} in "${trip.title}": ${changes.join(", ")}.`,
+        },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/journal-shared.ts
+++ b/src/tools/journal-shared.ts
@@ -79,6 +79,22 @@ export function findTripPlaces(trip: TripPlan, query: string): PlaceData[] {
   return [...byKey.values()].filter((p) => fold(p.name).includes(q));
 }
 
+/**
+ * The date of the itinerary day that schedules this place, if any — so a
+ * journal stop for a planned place defaults to the day it's planned on rather
+ * than today. Matches by place_id across dayPlan sections; returns undefined
+ * for unscheduled places (or places only present in the journal).
+ */
+export function placeItineraryDate(trip: TripPlan, place: PlaceData): string | undefined {
+  for (const section of trip.itinerary.sections) {
+    if (section.mode !== "dayPlan" || !section.date) continue;
+    for (const block of section.blocks) {
+      if (isPlaceBlock(block) && block.place.place_id === place.place_id) return section.date;
+    }
+  }
+  return undefined;
+}
+
 function preview(text: string): string {
   const flat = text.replace(/\n/g, " ").trim();
   return flat.length > 60 ? `${flat.slice(0, 57)}…` : flat;

--- a/src/tools/journal-shared.ts
+++ b/src/tools/journal-shared.ts
@@ -1,4 +1,5 @@
-import type { JournalStop, QuillDelta, TripPlan } from "../types.js";
+import type { JournalStop, PlaceData, QuillDelta, TripPlan } from "../types.js";
+import { isPlaceBlock } from "../types.js";
 
 /** A located journal stop: its index in the stops array plus the stop itself. */
 export type StopMatch = {
@@ -53,6 +54,29 @@ export function findStopMatches(trip: TripPlan, filters: StopFilters): StopMatch
     if (filters.date && stopDate(stop) !== filters.date) return false;
     return true;
   });
+}
+
+/**
+ * Finds places already referenced by the trip — both itinerary place blocks and
+ * existing journal-stop places — whose name matches the query (diacritic- and
+ * case-insensitive substring). Deduplicated by place_id. Lets add_journal reuse
+ * a place the user already has rather than embedding a fresh search result.
+ */
+export function findTripPlaces(trip: TripPlan, query: string): PlaceData[] {
+  const q = fold(query);
+  const byKey = new Map<string, PlaceData>();
+  const collect = (place: PlaceData | undefined) => {
+    if (!place?.name) return;
+    const key = place.place_id || place.name;
+    if (!byKey.has(key)) byKey.set(key, place);
+  };
+  for (const section of trip.itinerary.sections) {
+    for (const block of section.blocks) {
+      if (isPlaceBlock(block)) collect(block.place);
+    }
+  }
+  for (const { stop } of getJournalStops(trip)) collect(stop.place);
+  return [...byKey.values()].filter((p) => fold(p.name).includes(q));
 }
 
 function preview(text: string): string {

--- a/src/tools/journal-shared.ts
+++ b/src/tools/journal-shared.ts
@@ -1,0 +1,83 @@
+import type { JournalStop, QuillDelta, TripPlan } from "../types.js";
+
+/** A located journal stop: its index in the stops array plus the stop itself. */
+export type StopMatch = {
+  index: number;
+  stop: JournalStop;
+};
+
+export type StopFilters = {
+  title?: string;
+  date?: string;
+};
+
+/** Flattens a QuillDelta to plain text. */
+export function extractStopText(text: QuillDelta | undefined): string {
+  return (text?.ops ?? [])
+    .map((op) => (typeof op.insert === "string" ? op.insert : ""))
+    .join("");
+}
+
+/** The YYYY-MM-DD part of a stop's `dateTime`, or "" if absent. */
+export function stopDate(stop: JournalStop): string {
+  return typeof stop.dateTime === "string" ? stop.dateTime.slice(0, 10) : "";
+}
+
+/**
+ * Lowercase + strip diacritics so a user's "Senso-ji" matches a stop titled
+ * "Sensō-ji". Stop titles default to resolved place names, which routinely
+ * carry accents the user won't type.
+ */
+function fold(s: string): string {
+  return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+}
+
+/**
+ * Reads `trip.itinerary.journal.stops`, pairing each stop with its array index
+ * so callers can build JSON0 list paths. Empty when the trip has no journal.
+ */
+export function getJournalStops(trip: TripPlan): StopMatch[] {
+  const stops = trip.itinerary.journal?.stops ?? [];
+  return stops.map((stop, index) => ({ index, stop }));
+}
+
+/**
+ * Finds journal stops matching a diacritic- and case-insensitive title
+ * substring, optionally narrowed by an exact date (YYYY-MM-DD). An empty/omitted
+ * title matches every stop, so `list_journal` can call with filters alone.
+ */
+export function findStopMatches(trip: TripPlan, filters: StopFilters): StopMatch[] {
+  const title = filters.title ? fold(filters.title) : undefined;
+  return getJournalStops(trip).filter(({ stop }) => {
+    if (title && !fold(stop.title ?? "").includes(title)) return false;
+    if (filters.date && stopDate(stop) !== filters.date) return false;
+    return true;
+  });
+}
+
+function preview(text: string): string {
+  const flat = text.replace(/\n/g, " ").trim();
+  return flat.length > 60 ? `${flat.slice(0, 57)}…` : flat;
+}
+
+/** One-line label, e.g. `Marina Bay Sands — 2026-06-14 09:00 — "journal testing!"`. */
+export function formatStop(stop: JournalStop): string {
+  const title = stop.title?.trim() || stop.place?.name || "(untitled stop)";
+  const when =
+    typeof stop.dateTime === "string"
+      ? stop.dateTime.replace("T", " ").slice(0, 16)
+      : "(no date)";
+  const body = extractStopText(stop.text).trim();
+  const bodyLabel = body ? ` — "${preview(body)}"` : "";
+  return `${title} — ${when}${bodyLabel}`;
+}
+
+/** Numbered candidate list for an ambiguity prompt, capped with a "(N more…)" tail. */
+export function formatStopCandidateList(matches: StopMatch[], limit = 10): string {
+  const lines = matches
+    .slice(0, limit)
+    .map((m, i) => `  ${i + 1}. ${formatStop(m.stop)}`)
+    .join("\n");
+  const suffix = matches.length > limit ? `\n  (${matches.length - limit} more…)` : "";
+  return `${lines}${suffix}`;
+}

--- a/src/tools/list-journal.ts
+++ b/src/tools/list-journal.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError } from "../errors.js";
+import { findStopMatches, formatStop } from "./journal-shared.js";
+
+export const listJournalInputSchema = {
+  trip_key: z.string().min(1).describe("The trip whose journal to list."),
+  title: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Optional case-insensitive substring to filter stops by title."),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Optional exact date filter, YYYY-MM-DD."),
+};
+
+export const listJournalDescription = `
+Lists the stops in a Wanderlog trip's journal (travelogue), in order.
+
+Each line shows the stop's title, date/time, and a preview of its text entry. Use the optional
+title / date filters to narrow the list — handy for finding the exact stop to pass to
+wanderlog_edit_journal or wanderlog_remove_journal. Also reports the journal summary when set.
+
+Returns a friendly message when the trip has no journal stops.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  title?: string;
+  date?: string;
+};
+
+export async function listJournal(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const matches = findStopMatches(trip, { title: args.title, date: args.date });
+    const summary = trip.itinerary.journal?.summary?.trim();
+
+    if (matches.length === 0) {
+      const filtered = args.title || args.date;
+      const text = filtered
+        ? `No journal stops match those filters in "${trip.title}".`
+        : `"${trip.title}" has no journal stops yet. Add one with wanderlog_add_journal.`;
+      return { content: [{ type: "text", text }] };
+    }
+
+    const lines = matches.map((m, i) => `  ${i + 1}. ${formatStop(m.stop)}`).join("\n");
+    const noun = matches.length === 1 ? "stop" : "stops";
+    const summaryLine = summary ? `\n\nJournal summary: "${summary}"` : "";
+    return {
+      content: [
+        {
+          type: "text",
+          text: `${matches.length} journal ${noun} in "${trip.title}":\n${lines}${summaryLine}`,
+        },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/remove-journal.ts
+++ b/src/tools/remove-journal.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogNotFoundError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { findStopMatches, formatStop, formatStopCandidateList } from "./journal-shared.js";
+import { submitOp } from "./shared.js";
+
+export const removeJournalInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to remove the journal stop from."),
+  title: z
+    .string()
+    .min(1)
+    .describe("Case-insensitive substring matching the title of the journal stop to remove."),
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .optional()
+    .describe("Optional exact date filter to disambiguate duplicate titles, YYYY-MM-DD."),
+};
+
+export const removeJournalDescription = `
+Removes a stop from a Wanderlog trip's journal by matching a substring of its title.
+
+The match is case-insensitive. If exactly one stop matches, it is deleted. If none match, an
+error is returned. If several match, a numbered list is returned and nothing is deleted — re-call
+with a more specific title or add a date filter to pick one.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  title: string;
+  date?: string;
+};
+
+export async function removeJournal(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const trip = await ctx.tripCache.get(args.trip_key);
+    const matches = findStopMatches(trip, { title: args.title, date: args.date });
+
+    if (matches.length === 0) {
+      throw new WanderlogNotFoundError("Journal stop", args.title);
+    }
+
+    if (matches.length > 1) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `"${args.title}" matches ${matches.length} journal stops:\n${formatStopCandidateList(matches)}\n\nRe-call with a more specific title, or add a date filter to pick one.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const { index, stop } = matches[0]!;
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "journal", "stops", index],
+        ld: stop,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    return {
+      content: [
+        { type: "text", text: `Removed journal stop ${formatStop(stop)} from "${trip.title}".` },
+      ],
+    };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,29 @@ export type Geo = {
   bounds?: [number, number, number, number];
 };
 
+/**
+ * A stop in a trip's journal (travelogue). Each stop pins a place with a
+ * timestamp and a rich-text entry; `media` holds uploaded photos. Only the
+ * fields we read or edit are typed — the index signature preserves the rest.
+ */
+export type JournalStop = {
+  id: number;
+  type: string;
+  title?: string;
+  /** ISO datetime with a destination timezone offset, e.g. "2026-06-14T09:00+08:00". */
+  dateTime?: string;
+  place?: PlaceData;
+  text?: QuillDelta;
+  media?: unknown[];
+  [k: string]: unknown;
+};
+
+export type Journal = {
+  stops?: JournalStop[];
+  summary?: string;
+  [k: string]: unknown;
+};
+
 export type TripPlan = {
   id: number;
   key: string;
@@ -216,7 +239,7 @@ export type TripPlan = {
     sections: Section[];
     options?: unknown;
     budget?: Budget;
-    journal?: unknown;
+    journal?: Journal;
   };
   schemaVersion: number;
   createdAt: string;

--- a/tests/fixtures/journal-trip.ts
+++ b/tests/fixtures/journal-trip.ts
@@ -35,6 +35,20 @@ export const journalTrip: TripPlan = {
           },
         ],
       },
+      {
+        id: 200,
+        type: "normal",
+        mode: "dayPlan",
+        heading: "",
+        date: "2026-05-29",
+        blocks: [
+          {
+            id: 40002,
+            type: "place",
+            place: { name: "Tōchō-ji Temple", place_id: "ChIJtochoji" },
+          },
+        ],
+      },
     ],
     journal: {
       summary: "Three days of food in Fukuoka.",

--- a/tests/fixtures/journal-trip.ts
+++ b/tests/fixtures/journal-trip.ts
@@ -27,7 +27,13 @@ export const journalTrip: TripPlan = {
         mode: "placeList",
         heading: "Places to visit",
         date: null,
-        blocks: [],
+        blocks: [
+          {
+            id: 40001,
+            type: "place",
+            place: { name: "Ōhori Park", place_id: "ChIJohori" },
+          },
+        ],
       },
     ],
     journal: {

--- a/tests/fixtures/journal-trip.ts
+++ b/tests/fixtures/journal-trip.ts
@@ -1,0 +1,67 @@
+import type { TripPlan } from "../../src/types.ts";
+
+/**
+ * Fixture with a populated `itinerary.journal` for testing the list / add /
+ * edit / remove journal tools. Stops carry the real Wanderlog shape (embedded
+ * place, QuillDelta text, media, timezone-aware dateTime). Two "Ganso" stops
+ * exercise the ambiguity path; their dates differ so a date filter can pick one.
+ */
+export const journalTrip: TripPlan = {
+  id: 99999999,
+  key: "journaltripkey",
+  title: "Trip to Fukuoka",
+  userId: 3656632,
+  privacy: "private",
+  startDate: "2026-05-29",
+  endDate: "2026-05-31",
+  days: 3,
+  placeCount: 0,
+  schemaVersion: 2,
+  createdAt: "2026-05-01T00:00:00Z",
+  updatedAt: "2026-05-15T00:00:00Z",
+  itinerary: {
+    sections: [
+      {
+        id: 100,
+        type: "normal",
+        mode: "placeList",
+        heading: "Places to visit",
+        date: null,
+        blocks: [],
+      },
+    ],
+    journal: {
+      summary: "Three days of food in Fukuoka.",
+      stops: [
+        {
+          id: 571059554,
+          type: "confirmed",
+          title: "Ganso Hakata Mentaiju",
+          dateTime: "2026-05-29T09:00+09:00",
+          place: { name: "Ganso Hakata Mentaiju", place_id: "ChIJmentaiju" },
+          text: { ops: [{ insert: "Best mentaiko rice in the city." }] },
+          media: [],
+        },
+        {
+          id: 571059555,
+          type: "confirmed",
+          title: "Fushimi Inari Taisha",
+          dateTime: "2026-05-30T09:00+09:00",
+          place: { name: "Fushimi Inari Taisha", place_id: "ChIJfushimi" },
+          text: { ops: [{ insert: "Hiked the torii gates at dawn." }] },
+          media: [
+            { type: "uploaded", key: "abc123", width: 270, height: 148, mediaType: "image" },
+          ],
+        },
+        {
+          id: 571059556,
+          type: "confirmed",
+          title: "Ganso Hakata Mentaiju",
+          dateTime: "2026-05-31T12:00+09:00",
+          place: { name: "Ganso Hakata Mentaiju", place_id: "ChIJmentaiju" },
+          media: [],
+        },
+      ],
+    },
+  },
+};

--- a/tests/integration/journal.test.ts
+++ b/tests/integration/journal.test.ts
@@ -1,0 +1,127 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createContext, type AppContext } from "../../src/context.ts";
+import { createTrip } from "../../src/tools/create-trip.ts";
+import { addPlace } from "../../src/tools/add-place.ts";
+import { addJournal } from "../../src/tools/add-journal.ts";
+import { listJournal } from "../../src/tools/list-journal.ts";
+import { editJournal } from "../../src/tools/edit-journal.ts";
+import { removeJournal } from "../../src/tools/remove-journal.ts";
+import type { JournalStop, TripPlan } from "../../src/types.ts";
+
+/**
+ * Live round-trip for the journal tools against the real Wanderlog API.
+ * Creates a throwaway trip, adds a place (location anchor for place search),
+ * then adds / lists / edits / removes a journal stop — re-reading over REST
+ * between steps for authoritative assertions. Deletes the trip in afterAll.
+ *
+ * A stray trip from a mid-run crash shows up as "WANDERDOG_TEST_<timestamp>".
+ */
+describe("Journal tools (live round-trip)", () => {
+  let ctx: AppContext;
+  let tripKey: string | undefined;
+
+  const stopByTitle = (trip: TripPlan, sub: string): JournalStop | undefined =>
+    (trip.itinerary.journal?.stops ?? []).find((s) =>
+      (s.title ?? "").toLowerCase().includes(sub.toLowerCase()),
+    );
+
+  beforeAll(async () => {
+    if (!process.env.WANDERLOG_COOKIE) {
+      throw new Error("WANDERLOG_COOKIE must be set");
+    }
+    ctx = createContext();
+    const user = await ctx.rest.getUser();
+    ctx.userId = user.id;
+  }, 20_000);
+
+  afterAll(async () => {
+    ctx?.pool.closeAll();
+    if (tripKey) {
+      try {
+        await ctx.rest.deleteTrip(tripKey);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  it("creates a throwaway trip with a place anchor", async () => {
+    const result = await createTrip(ctx, {
+      destination: "Tokyo",
+      start_date: "2099-03-01",
+      end_date: "2099-03-03",
+      title: `WANDERDOG_TEST_${Date.now()}`,
+      privacy: "private",
+    });
+    expect(result.isError).not.toBe(true);
+    tripKey = /Key: (\w+)/.exec(result.content[0]!.text)?.[1];
+    expect(tripKey).toBeTruthy();
+    await addPlace(ctx, { trip_key: tripKey!, place: "Tokyo Tower" });
+  }, 30_000);
+
+  it("add_journal resolves a place and appends a stop", async () => {
+    const res = await addJournal(ctx, {
+      trip_key: tripKey!,
+      place: "Senso-ji",
+      text: "Visited the temple at dawn.",
+      date: "2099-03-02",
+      time: "08:30",
+    });
+    if (res.isError) throw new Error(`add_journal failed: ${res.content[0]!.text}`);
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    const stop = stopByTitle(trip, "sens"); // diacritic-free substring of "Sensō-ji"
+    expect(stop).toBeDefined();
+    expect(stop!.type).toBe("confirmed");
+    expect(stop!.place?.name).toMatch(/Sens/);
+    expect(stop!.dateTime).toBe("2099-03-02T08:30");
+    expect(stop!.media).toEqual([]);
+    expect(stop!.text?.ops?.[0]?.insert).toBe("Visited the temple at dawn.");
+  }, 30_000);
+
+  it("list_journal shows the stop", async () => {
+    const res = await listJournal(ctx, { trip_key: tripKey! });
+    expect(res.isError).not.toBe(true);
+    expect(res.content[0]!.text).toMatch(/Sens/);
+    expect(res.content[0]!.text).toContain("Visited the temple at dawn.");
+  }, 15_000);
+
+  it("edit_journal changes title/text/date and summary (server-confirmed)", async () => {
+    const res = await editJournal(ctx, {
+      trip_key: tripKey!,
+      title: "senso", // matches "Sensō-ji" via diacritic folding
+      new_title: "Sensō-ji (sunrise)",
+      new_text: "Beat the crowds before 9am.",
+      new_date: "2099-03-01",
+      new_summary: "Three days in Tokyo.",
+    });
+    if (res.isError) throw new Error(`edit_journal failed: ${res.content[0]!.text}`);
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    const stop = stopByTitle(trip, "sunrise");
+    expect(stop).toBeDefined();
+    expect(stop!.title).toBe("Sensō-ji (sunrise)");
+    expect(stop!.text?.ops?.[0]?.insert).toBe("Beat the crowds before 9am.");
+    expect(stop!.dateTime).toBe("2099-03-01T08:30"); // date changed, time preserved
+    expect(stop!.place?.name).toMatch(/Sens/); // place preserved
+    expect(trip.itinerary.journal?.summary).toBe("Three days in Tokyo.");
+  }, 30_000);
+
+  it("edit_journal returns not-found for a non-matching title", async () => {
+    const res = await editJournal(ctx, {
+      trip_key: tripKey!,
+      title: "no_such_stop_xyz",
+      new_text: "x",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text.toLowerCase()).toContain("not found");
+  }, 15_000);
+
+  it("remove_journal deletes the stop", async () => {
+    const res = await removeJournal(ctx, { trip_key: tripKey!, title: "sunrise" });
+    if (res.isError) throw new Error(`remove_journal failed: ${res.content[0]!.text}`);
+
+    const trip = await ctx.rest.getTrip(tripKey!);
+    expect(trip.itinerary.journal?.stops ?? []).toHaveLength(0);
+  }, 30_000);
+});

--- a/tests/integration/journal.test.ts
+++ b/tests/integration/journal.test.ts
@@ -45,7 +45,7 @@ describe("Journal tools (live round-trip)", () => {
     }
   });
 
-  it("creates a throwaway trip with a place anchor", async () => {
+  it("creates a throwaway trip with an itinerary place", async () => {
     const result = await createTrip(ctx, {
       destination: "Tokyo",
       start_date: "2099-03-01",
@@ -56,41 +56,52 @@ describe("Journal tools (live round-trip)", () => {
     expect(result.isError).not.toBe(true);
     tripKey = /Key: (\w+)/.exec(result.content[0]!.text)?.[1];
     expect(tripKey).toBeTruthy();
-    await addPlace(ctx, { trip_key: tripKey!, place: "Tokyo Tower" });
+    const place = await addPlace(ctx, { trip_key: tripKey!, place: "Tokyo Tower" });
+    if (place.isError) throw new Error(`add_place failed: ${place.content[0]!.text}`);
   }, 30_000);
 
-  it("add_journal resolves a place and appends a stop", async () => {
+  it("add_journal reuses an itinerary place (no override needed)", async () => {
     const res = await addJournal(ctx, {
       trip_key: tripKey!,
-      place: "Senso-ji",
-      text: "Visited the temple at dawn.",
+      place: "Tokyo Tower",
+      text: "Visited the tower at dawn.",
       date: "2099-03-02",
       time: "08:30",
     });
     if (res.isError) throw new Error(`add_journal failed: ${res.content[0]!.text}`);
+    expect(res.content[0]!.text).toContain("reused a place already in your trip");
 
     const trip = await ctx.rest.getTrip(tripKey!);
-    const stop = stopByTitle(trip, "sens"); // diacritic-free substring of "Sensō-ji"
+    const stop = stopByTitle(trip, "tokyo tower");
     expect(stop).toBeDefined();
     expect(stop!.type).toBe("confirmed");
-    expect(stop!.place?.name).toMatch(/Sens/);
+    expect(stop!.place?.name).toMatch(/Tokyo Tower/);
     expect(stop!.dateTime).toBe("2099-03-02T08:30");
     expect(stop!.media).toEqual([]);
-    expect(stop!.text?.ops?.[0]?.insert).toBe("Visited the temple at dawn.");
+    expect(stop!.text?.ops?.[0]?.insert).toBe("Visited the tower at dawn.");
   }, 30_000);
+
+  it("add_journal prompts (no mutation) for a place not in the itinerary", async () => {
+    const res = await addJournal(ctx, { trip_key: tripKey!, place: "Senso-ji" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("isn't a place in");
+    // unchanged: still exactly the one Tokyo Tower stop
+    const trip = await ctx.rest.getTrip(tripKey!);
+    expect(trip.itinerary.journal?.stops ?? []).toHaveLength(1);
+  }, 20_000);
 
   it("list_journal shows the stop", async () => {
     const res = await listJournal(ctx, { trip_key: tripKey! });
     expect(res.isError).not.toBe(true);
-    expect(res.content[0]!.text).toMatch(/Sens/);
-    expect(res.content[0]!.text).toContain("Visited the temple at dawn.");
+    expect(res.content[0]!.text).toMatch(/Tokyo Tower/);
+    expect(res.content[0]!.text).toContain("Visited the tower at dawn.");
   }, 15_000);
 
   it("edit_journal changes title/text/date and summary (server-confirmed)", async () => {
     const res = await editJournal(ctx, {
       trip_key: tripKey!,
-      title: "senso", // matches "Sensō-ji" via diacritic folding
-      new_title: "Sensō-ji (sunrise)",
+      title: "tokyo tower",
+      new_title: "Tokyo Tower (sunrise)",
       new_text: "Beat the crowds before 9am.",
       new_date: "2099-03-01",
       new_summary: "Three days in Tokyo.",
@@ -100,10 +111,10 @@ describe("Journal tools (live round-trip)", () => {
     const trip = await ctx.rest.getTrip(tripKey!);
     const stop = stopByTitle(trip, "sunrise");
     expect(stop).toBeDefined();
-    expect(stop!.title).toBe("Sensō-ji (sunrise)");
+    expect(stop!.title).toBe("Tokyo Tower (sunrise)");
     expect(stop!.text?.ops?.[0]?.insert).toBe("Beat the crowds before 9am.");
     expect(stop!.dateTime).toBe("2099-03-01T08:30"); // date changed, time preserved
-    expect(stop!.place?.name).toMatch(/Sens/); // place preserved
+    expect(stop!.place?.name).toMatch(/Tokyo Tower/); // place preserved
     expect(trip.itinerary.journal?.summary).toBe("Three days in Tokyo.");
   }, 30_000);
 

--- a/tests/integration/mcp-smoke.test.ts
+++ b/tests/integration/mcp-smoke.test.ts
@@ -87,7 +87,7 @@ describe("MCP stdio server (smoke)", () => {
     expect(p.pid).toBeDefined();
   });
 
-  it("responds to tools/list with all 21 tools", async () => {
+  it("responds to tools/list with all 26 tools", async () => {
     const p = startServer();
     await waitForReady(p);
     await initialize(p);
@@ -103,18 +103,23 @@ describe("MCP stdio server (smoke)", () => {
       "wanderlog_add_checklist",
       "wanderlog_add_expense",
       "wanderlog_add_hotel",
+      "wanderlog_add_journal",
       "wanderlog_add_note",
       "wanderlog_add_place",
       "wanderlog_annotate_place",
       "wanderlog_create_trip",
       "wanderlog_edit_expense",
+      "wanderlog_edit_journal",
       "wanderlog_edit_note",
       "wanderlog_get_guide",
       "wanderlog_get_trip",
+      "wanderlog_get_trip_forwarding_email",
       "wanderlog_get_trip_url",
       "wanderlog_list_expenses",
+      "wanderlog_list_journal",
       "wanderlog_list_trips",
       "wanderlog_remove_expense",
+      "wanderlog_remove_journal",
       "wanderlog_remove_note",
       "wanderlog_remove_place",
       "wanderlog_rename_day",

--- a/tests/unit/journal.test.ts
+++ b/tests/unit/journal.test.ts
@@ -162,6 +162,19 @@ describe("addJournal", () => {
     expect(op.li.text).toEqual({ ops: [{ insert: "Cherry blossoms by the lake." }] });
   });
 
+  it("defaults the date to the place's itinerary day when reused", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, noSearch);
+    const res = await addJournal(ctx, {
+      trip_key: "journaltripkey",
+      place: "Tocho", // "Tōchō-ji Temple", scheduled on 2026-05-29
+      text: "A quiet temple.",
+    });
+    expect(res.isError).toBeUndefined();
+    const op = submittedOps[0]![0] as { li: { dateTime: string; place: { place_id: string } } };
+    expect(op.li.dateTime).toBe("2026-05-29T09:00+09:00"); // the day it's planned on
+    expect(op.li.place.place_id).toBe("ChIJtochoji");
+  });
+
   it("reuses a place from an existing journal stop", async () => {
     const { ctx, submittedOps } = makeFakeContext(journalTrip, noSearch);
     const res = await addJournal(ctx, { trip_key: "journaltripkey", place: "ganso" });

--- a/tests/unit/journal.test.ts
+++ b/tests/unit/journal.test.ts
@@ -139,7 +139,47 @@ describe("listJournal", () => {
 // ---------------------------------------------------------------------------
 
 describe("addJournal", () => {
-  it("resolves a place and appends a stop, reusing the trip's tz offset", async () => {
+  const noSearch = { searchPlacesAutocomplete: async () => { throw new Error("should not search"); } };
+
+  it("reuses an existing itinerary place without searching", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, noSearch);
+    const res = await addJournal(ctx, {
+      trip_key: "journaltripkey",
+      place: "Ohori", // matches "Ōhori Park" via diacritic folding
+      text: "Cherry blossoms by the lake.",
+      date: "2026-05-31",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toContain("reused a place already in your trip");
+
+    const op = submittedOps[0]![0] as { p: (string | number)[]; li: Record<string, any> };
+    expect(op.p).toEqual(["itinerary", "journal", "stops", 3]); // appended after 3 existing
+    expect(op.li.type).toBe("confirmed");
+    expect(op.li.title).toBe("Ōhori Park"); // defaults to the reused place name
+    expect(op.li.place).toEqual({ name: "Ōhori Park", place_id: "ChIJohori" });
+    expect(op.li.dateTime).toBe("2026-05-31T09:00+09:00"); // offset reused from existing stops
+    expect(op.li.media).toEqual([]);
+    expect(op.li.text).toEqual({ ops: [{ insert: "Cherry blossoms by the lake." }] });
+  });
+
+  it("reuses a place from an existing journal stop", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, noSearch);
+    const res = await addJournal(ctx, { trip_key: "journaltripkey", place: "ganso" });
+    expect(res.isError).toBeUndefined();
+    const op = submittedOps[0]![0] as { li: { place: { place_id: string } } };
+    expect(op.li.place.place_id).toBe("ChIJmentaiju");
+  });
+
+  it("prompts (no mutation) when the place isn't in the trip", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, noSearch);
+    const res = await addJournal(ctx, { trip_key: "journaltripkey", place: "Canal City" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("isn't a place in");
+    expect(res.content[0]!.text).toContain("allow_new_place");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("adds a new place when allow_new_place is set", async () => {
     const { ctx, submittedOps } = makeFakeContext(journalTrip, {
       searchPlacesAutocomplete: async () => [{ place_id: "ChIJcanal", description: "Canal City" }],
       getPlaceDetails: async (id) => ({ name: "Canal City Hakata", place_id: id }),
@@ -147,29 +187,35 @@ describe("addJournal", () => {
     const res = await addJournal(ctx, {
       trip_key: "journaltripkey",
       place: "Canal City",
-      text: "Shopping and ramen stadium.",
+      allow_new_place: true,
       date: "2026-05-31",
     });
     expect(res.isError).toBeUndefined();
-    expect(res.content[0]!.text).toContain("Canal City Hakata");
-
-    const op = submittedOps[0]![0] as { p: (string | number)[]; li: Record<string, any> };
-    expect(op.p).toEqual(["itinerary", "journal", "stops", 3]); // appended after 3 existing
-    expect(op.li.type).toBe("confirmed");
-    expect(op.li.title).toBe("Canal City Hakata"); // defaults to place name
-    expect(op.li.dateTime).toBe("2026-05-31T09:00+09:00"); // offset reused from existing stops
+    expect(res.content[0]!.text).toContain("new place");
+    const op = submittedOps[0]![0] as { li: { place: any; dateTime: string } };
     expect(op.li.place).toEqual({ name: "Canal City Hakata", place_id: "ChIJcanal" });
-    expect(op.li.media).toEqual([]);
-    expect(op.li.text).toEqual({ ops: [{ insert: "Shopping and ramen stadium." }] });
+    expect(op.li.dateTime).toBe("2026-05-31T09:00+09:00");
   });
 
-  it("errors when the place reference matches nothing", async () => {
+  it("errors when the override search finds nothing", async () => {
     const { ctx, submittedOps } = makeFakeContext(journalTrip, {
       searchPlacesAutocomplete: async () => [],
     });
-    const res = await addJournal(ctx, { trip_key: "journaltripkey", place: "nowhere_xyz" });
+    const res = await addJournal(ctx, {
+      trip_key: "journaltripkey",
+      place: "nowhere_xyz",
+      allow_new_place: true,
+    });
     expect(res.isError).toBe(true);
     expect(res.content[0]!.text).toContain("No place found");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("is ambiguous when multiple trip places match", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await addJournal(ctx, { trip_key: "journaltripkey", place: "tai" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("matches 2 places");
     expect(submittedOps).toHaveLength(0);
   });
 });

--- a/tests/unit/journal.test.ts
+++ b/tests/unit/journal.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import type { TripPlan } from "../../src/types.ts";
+import {
+  findStopMatches,
+  formatStop,
+  getJournalStops,
+} from "../../src/tools/journal-shared.ts";
+import { listJournal } from "../../src/tools/list-journal.ts";
+import { addJournal } from "../../src/tools/add-journal.ts";
+import { editJournal } from "../../src/tools/edit-journal.ts";
+import { removeJournal } from "../../src/tools/remove-journal.ts";
+import { journalTrip } from "../fixtures/journal-trip.ts";
+
+function fresh(trip: TripPlan): TripPlan {
+  return structuredClone(trip);
+}
+
+type RestMock = {
+  searchPlacesAutocomplete?: (...a: any[]) => Promise<any[]>;
+  getPlaceDetails?: (id: string) => Promise<any>;
+};
+
+function makeFakeContext(
+  trip: TripPlan,
+  rest: RestMock = {},
+): { ctx: AppContext; submittedOps: Json0Op[][] } {
+  const submittedOps: Json0Op[][] = [];
+  const ctx = {
+    userId: 555,
+    rest: {
+      searchPlacesAutocomplete:
+        rest.searchPlacesAutocomplete ?? (async () => [{ place_id: "ChIJnew", description: "X" }]),
+      getPlaceDetails: rest.getPlaceDetails ?? (async (id: string) => ({ name: "New Place", place_id: id })),
+    },
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      get: async () => structuredClone(trip),
+      getEntry: async () => ({
+        snapshot: structuredClone(trip),
+        version: 1,
+        geos: [{ id: 1, name: "Fukuoka", latitude: 33.59, longitude: 130.4 }],
+      }),
+      applyLocalOp: () => {},
+      invalidate: () => {},
+    },
+  } as unknown as AppContext;
+  return { ctx, submittedOps };
+}
+
+// ---------------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------------
+
+describe("getJournalStops / findStopMatches / formatStop", () => {
+  it("returns indexed stops", () => {
+    const stops = getJournalStops(fresh(journalTrip));
+    expect(stops).toHaveLength(3);
+    expect(stops[0]!.index).toBe(0);
+  });
+
+  it("returns empty when there is no journal", () => {
+    const trip = fresh(journalTrip);
+    delete (trip.itinerary as { journal?: unknown }).journal;
+    expect(getJournalStops(trip)).toHaveLength(0);
+  });
+
+  it("matches a title substring case-insensitively", () => {
+    expect(findStopMatches(fresh(journalTrip), { title: "FUSHIMI" })).toHaveLength(1);
+  });
+
+  it("returns multiple matches for a shared title", () => {
+    expect(findStopMatches(fresh(journalTrip), { title: "ganso" })).toHaveLength(2);
+  });
+
+  it("matches across diacritics (Senso-ji finds Sensō-ji)", () => {
+    const trip = fresh(journalTrip);
+    trip.itinerary.journal!.stops![0]!.title = "Sensō-ji";
+    expect(findStopMatches(trip, { title: "senso-ji" })).toHaveLength(1);
+  });
+
+  it("narrows duplicates with a date filter", () => {
+    const m = findStopMatches(fresh(journalTrip), { title: "ganso", date: "2026-05-31" });
+    expect(m).toHaveLength(1);
+    expect(m[0]!.index).toBe(2);
+  });
+
+  it("formats a stop with title, datetime, and text preview", () => {
+    const stop = fresh(journalTrip).itinerary.journal!.stops![0]!;
+    expect(formatStop(stop)).toBe(
+      'Ganso Hakata Mentaiju — 2026-05-29 09:00 — "Best mentaiko rice in the city."',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listJournal
+// ---------------------------------------------------------------------------
+
+describe("listJournal", () => {
+  it("lists stops and the summary", async () => {
+    const { ctx } = makeFakeContext(journalTrip);
+    const res = await listJournal(ctx, { trip_key: "journaltripkey" });
+    expect(res.isError).toBeUndefined();
+    const text = res.content[0]!.text;
+    expect(text).toContain("3 journal stops");
+    expect(text).toContain("Fushimi Inari Taisha");
+    expect(text).toContain("Journal summary:");
+  });
+
+  it("filters by title", async () => {
+    const { ctx } = makeFakeContext(journalTrip);
+    const res = await listJournal(ctx, { trip_key: "journaltripkey", title: "fushimi" });
+    expect(res.content[0]!.text).toContain("1 journal stop");
+    expect(res.content[0]!.text).not.toContain("Ganso");
+  });
+
+  it("returns a friendly message when there are no stops", async () => {
+    const trip = fresh(journalTrip);
+    trip.itinerary.journal!.stops = [];
+    const { ctx } = makeFakeContext(trip);
+    const res = await listJournal(ctx, { trip_key: "journaltripkey" });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toContain("no journal stops yet");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addJournal
+// ---------------------------------------------------------------------------
+
+describe("addJournal", () => {
+  it("resolves a place and appends a stop, reusing the trip's tz offset", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, {
+      searchPlacesAutocomplete: async () => [{ place_id: "ChIJcanal", description: "Canal City" }],
+      getPlaceDetails: async (id) => ({ name: "Canal City Hakata", place_id: id }),
+    });
+    const res = await addJournal(ctx, {
+      trip_key: "journaltripkey",
+      place: "Canal City",
+      text: "Shopping and ramen stadium.",
+      date: "2026-05-31",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(res.content[0]!.text).toContain("Canal City Hakata");
+
+    const op = submittedOps[0]![0] as { p: (string | number)[]; li: Record<string, any> };
+    expect(op.p).toEqual(["itinerary", "journal", "stops", 3]); // appended after 3 existing
+    expect(op.li.type).toBe("confirmed");
+    expect(op.li.title).toBe("Canal City Hakata"); // defaults to place name
+    expect(op.li.dateTime).toBe("2026-05-31T09:00+09:00"); // offset reused from existing stops
+    expect(op.li.place).toEqual({ name: "Canal City Hakata", place_id: "ChIJcanal" });
+    expect(op.li.media).toEqual([]);
+    expect(op.li.text).toEqual({ ops: [{ insert: "Shopping and ramen stadium." }] });
+  });
+
+  it("errors when the place reference matches nothing", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, {
+      searchPlacesAutocomplete: async () => [],
+    });
+    const res = await addJournal(ctx, { trip_key: "journaltripkey", place: "nowhere_xyz" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("No place found");
+    expect(submittedOps).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeJournal
+// ---------------------------------------------------------------------------
+
+describe("removeJournal", () => {
+  it("returns not-found when nothing matches", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await removeJournal(ctx, { trip_key: "journaltripkey", title: "nope" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("not found");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("returns a candidate list and does not mutate when ambiguous", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await removeJournal(ctx, { trip_key: "journaltripkey", title: "ganso" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("matches 2 journal stops");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("deletes the matched stop with a JSON0 ld carrying the full object", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await removeJournal(ctx, { trip_key: "journaltripkey", title: "fushimi" });
+    expect(res.isError).toBeUndefined();
+    const op = submittedOps[0]![0] as { p: (string | number)[]; ld: { id: number } };
+    expect(op.p).toEqual(["itinerary", "journal", "stops", 1]);
+    expect(op.ld.id).toBe(571059555);
+    // applies cleanly, removing only that stop
+    const next = applyOp(fresh(journalTrip), submittedOps[0]!);
+    expect(next.itinerary.journal!.stops!.map((s) => s.title)).toEqual([
+      "Ganso Hakata Mentaiju",
+      "Ganso Hakata Mentaiju",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// editJournal
+// ---------------------------------------------------------------------------
+
+describe("editJournal", () => {
+  it("rejects when no new_* value is supplied", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await editJournal(ctx, { trip_key: "journaltripkey", title: "fushimi" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("Nothing to edit");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("requires a title when editing stop fields", async () => {
+    const { ctx } = makeFakeContext(journalTrip);
+    const res = await editJournal(ctx, { trip_key: "journaltripkey", new_text: "x" });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("Provide 'title'");
+  });
+
+  it("returns a candidate list and does not mutate when ambiguous", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await editJournal(ctx, {
+      trip_key: "journaltripkey",
+      title: "ganso",
+      new_text: "x",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("matches 2 journal stops");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("edits title and text with od+oi for only those fields", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await editJournal(ctx, {
+      trip_key: "journaltripkey",
+      title: "fushimi",
+      new_title: "Fushimi Inari (early)",
+      new_text: "Beat the crowds.",
+    });
+    expect(res.isError).toBeUndefined();
+    const ops = submittedOps[0]!;
+    expect(ops).toContainEqual({
+      p: ["itinerary", "journal", "stops", 1, "title"],
+      od: "Fushimi Inari Taisha",
+      oi: "Fushimi Inari (early)",
+    });
+    expect(ops).toContainEqual({
+      p: ["itinerary", "journal", "stops", 1, "text"],
+      od: { ops: [{ insert: "Hiked the torii gates at dawn." }] },
+      oi: { ops: [{ insert: "Beat the crowds." }] },
+    });
+  });
+
+  it("edits the date while preserving the timezone offset", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await editJournal(ctx, {
+      trip_key: "journaltripkey",
+      title: "fushimi",
+      new_date: "2026-05-28",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(submittedOps[0]![0]).toEqual({
+      p: ["itinerary", "journal", "stops", 1, "dateTime"],
+      od: "2026-05-30T09:00+09:00",
+      oi: "2026-05-28T09:00+09:00",
+    });
+  });
+
+  it("edits the trip-level summary without a stop title", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    const res = await editJournal(ctx, {
+      trip_key: "journaltripkey",
+      new_summary: "Best food trip ever.",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(submittedOps[0]![0]).toEqual({
+      p: ["itinerary", "journal", "summary"],
+      od: "Three days of food in Fukuoka.",
+      oi: "Best food trip ever.",
+    });
+  });
+
+  it("preserves place and media when applied via applyOp", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip);
+    await editJournal(ctx, {
+      trip_key: "journaltripkey",
+      title: "fushimi",
+      new_title: "Fushimi Inari (early)",
+      new_text: "Beat the crowds.",
+    });
+    const next = applyOp(fresh(journalTrip), submittedOps[0]!);
+    const stop = next.itinerary.journal!.stops![1]!;
+    expect(stop.title).toBe("Fushimi Inari (early)");
+    expect(stop.place).toEqual({ name: "Fushimi Inari Taisha", place_id: "ChIJfushimi" });
+    expect(stop.media).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds four MCP tools for managing a trip's **journal** (Wanderlog's travelogue, at `itinerary.journal.stops`): `wanderlog_list_journal`, `wanderlog_add_journal`, `wanderlog_edit_journal`, and `wanderlog_remove_journal`. A journal is an ordered list of *stops*, each pinning a place with a date/time, a rich-text entry, and optional photos, plus a trip-level `summary`.

Stops are selected by a **diacritic- and case-insensitive title substring** (so `"Senso-ji"` finds `"Sensō-ji"` — titles default to resolved place names, which carry accents users won't type), with an optional `date` filter. Zero matches → friendly not-found error; multiple → numbered candidate list with no mutation.

**Place handling in `add_journal`** (this is the considered part):
- It **reuses a place already in the trip** — an itinerary place or an existing journal stop matching the name — embedding that exact place (same `place_id`) rather than a fresh search result.
- When reusing a place that's scheduled on an itinerary day, the new stop **defaults its date to that day** (an explicit `date` still wins).
- When the place **isn't in the trip**, it does **not** add it silently — it returns a prompt to add it to the itinerary first (`wanderlog_add_place`) or to re-call with `allow_new_place: true` to journal it as a new (unplanned) place. The safe behavior is the default in code, not just guidance.

**`edit_journal`** submits `od`+`oi` only for changed fields (title, text, date, time), preserving the stop's `place`, `media`, and unknown fields; it can also set the trip-level journal `summary`. **`remove_journal`** uses a JSON0 `ld`. `dateTime` is stored with the destination's timezone offset, reused from an existing stop when present (the server also accepts a bare local datetime, verified live).

A `JOURNALING` section was added to `SERVER_INSTRUCTIONS` so any connecting agent learns the workflow up front. Reusable `JournalStop` / `Journal` types and shared helpers (`getJournalStops`, `findStopMatches`, `findTripPlaces`, `placeItineraryDate`, `formatStop`) back the tools.

## Test plan

- `npm run typecheck`, `npm run build`, and `npm run test` pass — 290 unit tests, including coverage for diacritic-tolerant matching, place reuse (itinerary + journal sources), the ambiguity prompt (no mutation), the not-in-itinerary prompt, the `allow_new_place` override, date-defaulting to the place's itinerary day, per-field `od`+`oi` edits, the summary path, `dateTime` rebuild preserving the tz offset, deletion, and end-to-end application of the generated ops through the real `applyOp` (asserting `place`/`media` survive an edit).
- New gated live integration test (`tests/integration/journal.test.ts`, 7 cases): creates a throwaway trip with a place, then exercises reuse, the not-in-itinerary prompt, list, edit (title/text/date/summary, server-confirmed), and remove — re-reading over REST between steps. Auto-deletes the trip. The smoke test now asserts all **22** tools. Both verified green against the live Wanderlog API.
- Reverse-engineered the (previously untyped) journal shape across 25 real trips, then validated every tool end-to-end on a live throwaway trip and a real trip — which is what surfaced the diacritic-matching need, the date-should-follow-the-itinerary-day behavior, and confirmation that whole-delta `od`+`oi` text edits are accepted server-side (no rich-text subtype op required).

## Agent-facing surface changes

- [x] Changed a tool description, parameter doc, or error message
      (four new journal tool descriptions/params, their prompt/error messages,
      and a new JOURNALING section in SERVER_INSTRUCTIONS — reviewed for
      injection risk and clarity)
