### PR TITLE
Fix #10: set place imageKeys so photos show on iOS/iPadOS

### DIFF
--- a/src/tools/add-hotel.ts
+++ b/src/tools/add-hotel.ts
@@ -80,8 +80,12 @@ export async function addHotel(
       );
     }
     const detail: PlaceData = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
+    // Fetch the Wanderlog-hosted imageKeys so the hotel shows a photo in the
+    // iOS / iPadOS apps (they render from block.imageKeys, not photo_urls).
+    const imageKeys = await ctx.rest.getPlaceImageKeys(predictions[0]!.place_id);
 
     const block = buildPlaceBlock(detail, userId, {
+      imageKeys,
       hotel: {
         checkIn: args.check_in,
         checkOut: args.check_out,

--- a/src/tools/add-place.ts
+++ b/src/tools/add-place.ts
@@ -135,10 +135,13 @@ export async function addPlace(
     }
     const topPrediction = predictions[0]!;
     const detail: PlaceData = await ctx.rest.getPlaceDetails(topPrediction.place_id);
+    // Fetch the Wanderlog-hosted imageKeys so the place shows a photo in the
+    // iOS / iPadOS apps (they render from block.imageKeys, not photo_urls).
+    const imageKeys = await ctx.rest.getPlaceImageKeys(topPrediction.place_id);
 
     // Build the block WITHOUT timing — timing is set via separate oi ops
     // to match the Wanderlog UI's two-step pattern (insert block, then set fields).
-    const block = buildPlaceBlock(detail, userId);
+    const block = buildPlaceBlock(detail, userId, { imageKeys });
     const section = trip.itinerary.sections[targetIndex]!;
     const insertIndex = section.blocks.length;
     const blockPath = ["itinerary", "sections", targetIndex, "blocks", insertIndex];

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -127,6 +127,7 @@ export function buildPlaceBlock(
     };
     startTime?: string;
     endTime?: string;
+    imageKeys?: string[];
   } = {},
 ): Block {
   const base: Record<string, unknown> = {
@@ -140,6 +141,13 @@ export function buildPlaceBlock(
     travelMode: null,
     attachments: [],
   };
+  // The mobile apps render the place photo from `imageKeys` stored on the
+  // block, not from the place's Google `photo_urls`. Without this, MCP-added
+  // places show no image on iOS / iPadOS (the web app fetches photos live, so
+  // it is unaffected). Only set the key when we actually have images.
+  if (extras.imageKeys && extras.imageKeys.length > 0) {
+    base.imageKeys = extras.imageKeys;
+  }
   if (extras.hotel) {
     base.hotel = {
       checkIn: extras.hotel.checkIn,

--- a/src/transport/rest.ts
+++ b/src/transport/rest.ts
@@ -168,6 +168,21 @@ export class RestClient {
     return env.data;
   }
 
+  /**
+   * Fetches Wanderlog place metadata (including the hosted `imageKeys` used by
+   * the mobile apps) for one place. The native "add place" flow calls this
+   * endpoint and stores the returned imageKeys on the itinerary block; the
+   * getPlaceDetails endpoint only returns Google `photo_urls`, which the iOS /
+   * iPadOS apps do not render. Returns an empty array if none are available.
+   */
+  async getPlaceImageKeys(placeId: string): Promise<string[]> {
+    const env = await this.request<
+      Envelope<{ data?: Array<{ placeId?: string; imageKeys?: string[] }> }>
+    >("GET", `/api/places/metadata?placeIds=${encodeURIComponent(placeId)}`);
+    const entry = env.data?.find((e) => e.placeId === placeId) ?? env.data?.[0];
+    return entry?.imageKeys ?? [];
+  }
+
   async geoAutocomplete(
     query: string,
   ): Promise<Array<{ id: number; name: string; countryName?: string; stateName?: string; latitude: number; longitude: number; popularity?: number }>> {


### PR DESCRIPTION
Fixes #10.

## Problem

Places (and hotels) added through the MCP show their photo on the **web** app, but show **no photo in the iOS / iPadOS apps**. Places added manually through any native interface display photos everywhere.

## Root cause

The mobile apps render a place's photo from an **`imageKeys` array stored on the itinerary block**. The web app is unaffected because it fetches photos live from the Google `place_id`, so the missing field is invisible there.

The MCP's add flow only calls `GET /api/placesAPI/getPlaceDetails/v2`, which returns Google `photo_urls` but **never `imageKeys`**. So `buildPlaceBlock` had no imageKeys to set, and the block was persisted without them.

The native "add place" flow resolves them with a separate call the MCP was missing:

```
GET /api/places/metadata?placeIds={placeId}
→ { success: true, data: [ { placeId, imageKeys: [ … ], … } ] }
```

I confirmed this by intercepting the web app's network traffic while adding a place via the native search bar: `/api/places/metadata` is the only call that returns `imageKeys`, and the resulting block carries them (whereas an MCP-added block does not).

## Fix

- Add `RestClient.getPlaceImageKeys(placeId)` that calls `/api/places/metadata?placeIds=…` and returns the `imageKeys` array (empty if none).
- Thread the result through `buildPlaceBlock` (the `PlaceBlock` type already has an optional `imageKeys?: string[]` field — it was just never populated) in `add-place` and `add-hotel`.
- `imageKeys` is only set on the block when non-empty, so places without photos are unaffected.

## Testing

- `npm run typecheck` — passes.
- `npm test` — all 263 unit tests pass.
- Manually verified end-to-end against a live trip: a place added via the native search bar gets `block.imageKeys` (and shows on iOS); an MCP-added place did not. The `/api/places/metadata` endpoint returns the same imageKeys for that place's `place_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
