### PR TITLE
Configure Node.js matrix testing in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,17 @@ on:
 
 jobs:
   test:
+    name: test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24, 26]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm run typecheck


### PR DESCRIPTION
This pull request expands the CI test job to run across a matrix of Node.js versions (22, 24, 26) instead of testing only on Node 22.

### Changes
- Configured a matrix strategy for the `test` job in `.github/workflows/ci.yml`.
- Expanded testing to run on Node.js versions 22, 24, and 26.
- Set `fail-fast: false` to ensure test runs for all Node versions are completed even if one fails.
- Parameterized `actions/setup-node` to use the dynamic matrix node version.
