### PR TITLE
Upgrade GitHub Actions versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
Upgrades GitHub Actions to their latest versions in the CI workflow:

- Upgrades actions/checkout from v4 to v7
- Upgrades actions/setup-node from v4 to v6