### PR TITLE
Add build and test caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,19 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - name: Cache build output
+        id: cache-build
+        uses: actions/cache@v5
+        with:
+          path: dist
+          key: ${{ runner.os }}-dist-${{ hashFiles('src/**/*.ts', 'tsconfig.json') }}
+      - name: Cache vitest
+        uses: actions/cache@v5
+        with:
+          path: node_modules/.cache/vitest
+          key: ${{ runner.os }}-vitest-${{ hashFiles('src/**/*.ts', 'tests/**/*.ts') }}
       - run: npm ci
       - run: npm run typecheck
       - run: npm run build
+        if: steps.cache-build.outputs.cache-hit != 'true'
       - run: npm run test


### PR DESCRIPTION
This pull request introduces build and test caching to the GitHub Actions CI workflow to speed up CI runs.

### Changes
- **Build Output Caching**: Caches the `dist` directory to avoid rebuilding when source files have not changed.
- **Vitest Cache**: Caches the `node_modules/.cache/vitest` directory to speed up test execution.
- **Conditional Build Step**: Executes `npm run build` only when there is a cache miss on the build output.
