### PR TITLE
Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Add a Dependabot configuration (`.github/dependabot.yml`) to automatically monitor and update project dependencies. It is configured to perform weekly checks for both `npm` packages and GitHub Actions. To prevent pull request fatigue, all minor and patch updates for `npm` are grouped into a single weekly pull request.

## Test plan

Validated that `.github/dependabot.yml` is syntactically correct and adheres to the Dependabot v2 schema. The configuration will be verified and ingested automatically by GitHub's Dependabot service upon merging.
