### PR TITLE
Validate semantic correctness of time and date inputs client-side

### DIFF
--- a/src/tools/add-place.ts
+++ b/src/tools/add-place.ts
@@ -11,6 +11,7 @@ import {
   findTripCenter,
   requireUserId,
   submitOp,
+  validateTimeInputs,
 } from "./shared.js";
 
 export const addPlaceInputSchema = {
@@ -77,6 +78,7 @@ export async function addPlace(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
+    validateTimeInputs(args.start_time, args.end_time);
     const userId = requireUserId(ctx);
     const entry = await ctx.tripCache.getEntry(args.trip_key);
     const trip = entry.snapshot;

--- a/src/tools/annotate-place.ts
+++ b/src/tools/annotate-place.ts
@@ -4,7 +4,7 @@ import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import { resolvePlaceRef } from "../resolvers/place-ref.js";
 import { isPlaceBlock } from "../types.js";
-import { submitOp } from "./shared.js";
+import { submitOp, validateTimeInputs } from "./shared.js";
 
 export const annotatePlaceInputSchema = {
   trip_key: z
@@ -57,6 +57,7 @@ export async function annotatePlace(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
+    validateTimeInputs(args.start_time, args.end_time);
     if (!args.note && !args.start_time && !args.end_time) {
       throw new WanderlogValidationError(
         "At least one of note, start_time, or end_time must be provided",

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -283,3 +283,32 @@ export function buildChecklistBlock(
     attachments: [],
   };
 }
+
+const TIME_REGEX = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+export function validateTimeInputs(startTime?: string, endTime?: string): void {
+  if (startTime && !TIME_REGEX.test(startTime)) {
+    throw new WanderlogValidationError(
+      `Invalid start_time: "${startTime}". Hours must be between 00 and 23, and minutes between 00 and 59.`,
+    );
+  }
+  if (endTime && !TIME_REGEX.test(endTime)) {
+    throw new WanderlogValidationError(
+      `Invalid end_time: "${endTime}". Hours must be between 00 and 23, and minutes between 00 and 59.`,
+    );
+  }
+}
+
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidDate(dateStr: string): boolean {
+  if (!DATE_REGEX.test(dateStr)) return false;
+
+  const [year, month, day] = dateStr.split("-").map((s) => parseInt(s, 10));
+  const date = new Date(Date.UTC(year!, month! - 1, day!));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month! - 1 &&
+    date.getUTCDate() === day
+  );
+}

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -297,6 +297,13 @@ export function validateTimeInputs(startTime?: string, endTime?: string): void {
       `Invalid end_time: "${endTime}". Hours must be between 00 and 23, and minutes between 00 and 59.`,
     );
   }
+  // Format is validated above, so a lexicographic compare on zero-padded HH:mm
+  // is equivalent to a chronological compare.
+  if (startTime && endTime && startTime >= endTime) {
+    throw new WanderlogValidationError(
+      `end_time (${endTime}) must be after start_time (${startTime}).`,
+    );
+  }
 }
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -311,4 +318,14 @@ export function isValidDate(dateStr: string): boolean {
     date.getUTCMonth() === month! - 1 &&
     date.getUTCDate() === day
   );
+}
+
+export function validateDateRange(startDate: string, endDate: string): void {
+  // Both dates are validated as YYYY-MM-DD before this runs, so a
+  // lexicographic compare matches chronological order.
+  if (startDate > endDate) {
+    throw new WanderlogValidationError(
+      `end_date (${endDate}) must be on or after start_date (${startDate}).`,
+    );
+  }
 }

--- a/src/tools/update-trip-dates.ts
+++ b/src/tools/update-trip-dates.ts
@@ -3,7 +3,7 @@ import type { AppContext } from "../context.js";
 import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import type { Section, TripPlan } from "../types.js";
-import { generateBlockId, submitOp, isValidDate } from "./shared.js";
+import { generateBlockId, submitOp, isValidDate, validateDateRange } from "./shared.js";
 
 export const updateTripDatesInputSchema = {
   trip_key: z.string().min(1).describe("The trip to update."),
@@ -259,6 +259,7 @@ export async function updateTripDates(
         `Invalid end_date: "${args.end_date}". Must be a valid calendar date.`,
       );
     }
+    validateDateRange(args.start_date, args.end_date);
     const trip = await ctx.tripCache.get(args.trip_key);
     const ops = buildUpdateDatesOps(
       trip,

--- a/src/tools/update-trip-dates.ts
+++ b/src/tools/update-trip-dates.ts
@@ -3,7 +3,7 @@ import type { AppContext } from "../context.js";
 import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import type { Section, TripPlan } from "../types.js";
-import { generateBlockId, submitOp } from "./shared.js";
+import { generateBlockId, submitOp, isValidDate } from "./shared.js";
 
 export const updateTripDatesInputSchema = {
   trip_key: z.string().min(1).describe("The trip to update."),
@@ -249,6 +249,16 @@ export async function updateTripDates(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
+    if (!isValidDate(args.start_date)) {
+      throw new WanderlogValidationError(
+        `Invalid start_date: "${args.start_date}". Must be a valid calendar date.`,
+      );
+    }
+    if (!isValidDate(args.end_date)) {
+      throw new WanderlogValidationError(
+        `Invalid end_date: "${args.end_date}". Must be a valid calendar date.`,
+      );
+    }
     const trip = await ctx.tripCache.get(args.trip_key);
     const ops = buildUpdateDatesOps(
       trip,

--- a/tests/unit/semantic-validation.test.ts
+++ b/tests/unit/semantic-validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { validateTimeInputs, isValidDate } from "../../src/tools/shared.ts";
+import { validateTimeInputs, isValidDate, validateDateRange } from "../../src/tools/shared.ts";
+import { annotatePlace } from "../../src/tools/annotate-place.ts";
 import { addPlace } from "../../src/tools/add-place.ts";
 import { updateTripDates } from "../../src/tools/update-trip-dates.ts";
 import { WanderlogValidationError } from "../../src/errors.ts";
@@ -19,6 +20,29 @@ describe("validateTimeInputs", () => {
     expect(() => validateTimeInputs("09:60")).toThrow(WanderlogValidationError);
     expect(() => validateTimeInputs("09:99")).toThrow(WanderlogValidationError);
     expect(() => validateTimeInputs("abc:12")).toThrow(WanderlogValidationError);
+  });
+
+  it("rejects a non-chronological time range", () => {
+    expect(() => validateTimeInputs("11:30", "09:00")).toThrow(WanderlogValidationError);
+    expect(() => validateTimeInputs("09:00", "09:00")).toThrow(WanderlogValidationError);
+  });
+
+  it("does not range-check when only one bound is given", () => {
+    expect(() => validateTimeInputs("11:30")).not.toThrow();
+    expect(() => validateTimeInputs(undefined, "09:00")).not.toThrow();
+  });
+});
+
+describe("validateDateRange", () => {
+  it("accepts start before or equal to end", () => {
+    expect(() => validateDateRange("2026-05-03", "2026-05-08")).not.toThrow();
+    expect(() => validateDateRange("2026-05-03", "2026-05-03")).not.toThrow();
+  });
+
+  it("rejects start after end", () => {
+    expect(() => validateDateRange("2026-05-10", "2026-05-05")).toThrow(
+      WanderlogValidationError,
+    );
   });
 });
 
@@ -49,6 +73,34 @@ describe("addPlace input validation", () => {
     expect(res.isError).toBe(true);
     expect(res.content[0]?.text).toContain("Invalid start_time");
   });
+
+  it("returns isError: true when end_time is not after start_time", async () => {
+    const fakeCtx = {} as AppContext;
+    const args = {
+      trip_key: "tripA",
+      place: "Louvre",
+      start_time: "11:30",
+      end_time: "09:00",
+    };
+    const res = await addPlace(fakeCtx, args);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("must be after start_time");
+  });
+});
+
+describe("annotatePlace input validation", () => {
+  it("returns isError: true when end_time is not after start_time", async () => {
+    const fakeCtx = {} as AppContext;
+    const args = {
+      trip_key: "tripA",
+      place: "Louvre",
+      start_time: "09:00",
+      end_time: "09:00",
+    };
+    const res = await annotatePlace(fakeCtx, args);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("must be after start_time");
+  });
 });
 
 describe("updateTripDates input validation", () => {
@@ -62,5 +114,17 @@ describe("updateTripDates input validation", () => {
     const res = await updateTripDates(fakeCtx, args);
     expect(res.isError).toBe(true);
     expect(res.content[0]?.text).toContain("Invalid start_date");
+  });
+
+  it("returns isError: true when end_date is before start_date", async () => {
+    const fakeCtx = {} as AppContext;
+    const args = {
+      trip_key: "tripA",
+      start_date: "2026-05-10",
+      end_date: "2026-05-05",
+    };
+    const res = await updateTripDates(fakeCtx, args);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("must be on or after start_date");
   });
 });

--- a/tests/unit/semantic-validation.test.ts
+++ b/tests/unit/semantic-validation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { validateTimeInputs, isValidDate } from "../../src/tools/shared.ts";
+import { addPlace } from "../../src/tools/add-place.ts";
+import { updateTripDates } from "../../src/tools/update-trip-dates.ts";
+import { WanderlogValidationError } from "../../src/errors.ts";
+import type { AppContext } from "../../src/context.ts";
+
+describe("validateTimeInputs", () => {
+  it("accepts valid times and ranges", () => {
+    expect(() => validateTimeInputs("09:00")).not.toThrow();
+    expect(() => validateTimeInputs("00:00")).not.toThrow();
+    expect(() => validateTimeInputs("23:59")).not.toThrow();
+    expect(() => validateTimeInputs("09:00", "11:30")).not.toThrow();
+  });
+
+  it("rejects invalid hours or minutes", () => {
+    expect(() => validateTimeInputs("24:00")).toThrow(WanderlogValidationError);
+    expect(() => validateTimeInputs("25:00")).toThrow(WanderlogValidationError);
+    expect(() => validateTimeInputs("09:60")).toThrow(WanderlogValidationError);
+    expect(() => validateTimeInputs("09:99")).toThrow(WanderlogValidationError);
+    expect(() => validateTimeInputs("abc:12")).toThrow(WanderlogValidationError);
+  });
+});
+
+describe("isValidDate", () => {
+  it("accepts valid calendar dates", () => {
+    expect(isValidDate("2026-05-03")).toBe(true);
+    expect(isValidDate("2024-02-29")).toBe(true); // leap year
+  });
+
+  it("rejects invalid calendar dates", () => {
+    expect(isValidDate("2026-02-29")).toBe(false); // non-leap year
+    expect(isValidDate("2026-04-31")).toBe(false); // april has 30 days
+    expect(isValidDate("2026-13-01")).toBe(false); // invalid month
+    expect(isValidDate("2026-05-32")).toBe(false); // invalid day
+    expect(isValidDate("abc")).toBe(false);
+  });
+});
+
+describe("addPlace input validation", () => {
+  it("returns isError: true on semantically invalid times", async () => {
+    const fakeCtx = {} as AppContext;
+    const args = {
+      trip_key: "tripA",
+      place: "Louvre",
+      start_time: "25:00",
+    };
+    const res = await addPlace(fakeCtx, args);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("Invalid start_time");
+  });
+});
+
+describe("updateTripDates input validation", () => {
+  it("returns isError: true on semantically invalid dates", async () => {
+    const fakeCtx = {} as AppContext;
+    const args = {
+      trip_key: "tripA",
+      start_date: "2026-02-29", // invalid
+      end_date: "2026-03-01",
+    };
+    const res = await updateTripDates(fakeCtx, args);
+    expect(res.isError).toBe(true);
+    expect(res.content[0]?.text).toContain("Invalid start_date");
+  });
+});


### PR DESCRIPTION
## Summary

Adds client-side semantic validation for scheduled block times and trip dates, so bad input fails fast and locally instead of round-tripping to the Wanderlog API. Two layers of validation:

**Format / calendar validity**
- Times (`HH:MM`, 24-hour): a regex rejects out-of-range hours (>= 24) and minutes (>= 60). Wired into `wanderlog_add_place` and `wanderlog_annotate_place`.
- Dates (`YYYY-MM-DD`): a regex plus a native UTC `Date` round-trip rejects non-existent calendar dates (e.g. `2026-02-29`, `2026-04-31`), correctly handling month lengths and leap years. Wired into `wanderlog_update_trip_dates`.

**Chronological range**
- When both `start_time` and `end_time` are given, rejects `end_time <= start_time` (`validateTimeInputs` in `src/tools/shared.ts`; add-place and annotate-place already pass both bounds).
- When both `start_date` and `end_date` are given, rejects `end_date < start_date` (new `validateDateRange` helper in `src/tools/shared.ts`, called in `update-trip-dates` before the mutation).

Both range checks are lexicographic string compares on the already-format-validated inputs, which is equivalent to a chronological compare — no integer/date math needed. Validation runs inside each tool ahead of `submitOp`, so all mutations still go through the shared submit helper.

No new dependencies (native regex + `Date` only).

## Test plan

Unit tests in `tests/unit/semantic-validation.test.ts` cover:
- `validateTimeInputs`: valid times accepted; invalid hours/minutes rejected; non-chronological range (`end <= start`) rejected; single-bound inputs not range-checked.
- `validateDateRange`: `start <= end` accepted (including equal); `start > end` rejected.
- `isValidDate`: valid calendar dates (incl. leap year) accepted; invalid dates rejected.
- Tool level: `addPlace` and `annotatePlace` return `isError: true` on invalid/backwards times; `updateTripDates` returns `isError: true` on invalid dates and on `end_date` before `start_date`.

Commands run (integration suite skipped — needs live Wanderlog credentials):

```
npm run build       # passes
npm run typecheck   # passes
npm run test        # 346 passed (27 files)
```