### PR TITLE
Fix event listener leak in `TripCache` on remote operations

### DIFF
--- a/src/cache/trip-cache.ts
+++ b/src/cache/trip-cache.ts
@@ -7,6 +7,7 @@ type CacheEntry = {
   snapshot: TripPlan;
   version: number;
   geos: Geo[];
+  listener?: (ops: Json0Op[], version: number) => void;
 };
 
 /**
@@ -61,10 +62,8 @@ export class TripCache {
 
     const client = this.pool.get(tripKey);
     const snapshot = await client.subscribe();
-    const entry: CacheEntry = { snapshot, version: client.version, geos };
-    this.entries.set(tripKey, entry);
 
-    client.on("remoteOp", (ops: Json0Op[], version: number) => {
+    const listener = (ops: Json0Op[], version: number) => {
       const current = this.entries.get(tripKey);
       if (!current) return;
       try {
@@ -73,9 +72,14 @@ export class TripCache {
       } catch {
         // If a remote op fails to apply to our snapshot, our view is stale.
         // Drop the entry; next get() re-subscribes from a fresh snapshot.
-        this.entries.delete(tripKey);
+        this.deleteEntry(tripKey);
       }
-    });
+    };
+
+    client.on("remoteOp", listener);
+
+    const entry: CacheEntry = { snapshot, version: client.version, geos, listener };
+    this.entries.set(tripKey, entry);
 
     return entry;
   }
@@ -91,11 +95,24 @@ export class TripCache {
     entry.version = newVersion;
   }
 
+  private deleteEntry(tripKey: string): void {
+    const entry = this.entries.get(tripKey);
+    if (entry) {
+      if (entry.listener) {
+        const client = this.pool.get(tripKey);
+        client.off("remoteOp", entry.listener);
+      }
+      this.entries.delete(tripKey);
+    }
+  }
+
   invalidate(tripKey: string): void {
-    this.entries.delete(tripKey);
+    this.deleteEntry(tripKey);
   }
 
   clear(): void {
-    this.entries.clear();
+    for (const tripKey of this.entries.keys()) {
+      this.deleteEntry(tripKey);
+    }
   }
 }

--- a/tests/unit/trip-cache.test.ts
+++ b/tests/unit/trip-cache.test.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it } from "vitest";
+import { TripCache } from "../../src/cache/trip-cache.ts";
+import type { RestClient } from "../../src/transport/rest.ts";
+import type { ShareDBPool } from "../../src/transport/sharedb.ts";
+
+class FakeShareDBClient extends EventEmitter {
+  public version = 1;
+  public subscribeCalled = 0;
+
+  async subscribe() {
+    this.subscribeCalled++;
+    return { title: "Test Trip", sections: [] };
+  }
+}
+
+describe("TripCache event listener leak", () => {
+  it("unregisters remoteOp listener on invalidate", async () => {
+    const fakeClient = new FakeShareDBClient();
+    const fakeRest = {
+      getTripWithResources: async () => ({ geos: [] }),
+    } as unknown as RestClient;
+
+    const fakePool = {
+      get: () => fakeClient,
+    } as unknown as ShareDBPool;
+
+    const cache = new TripCache(fakeRest, fakePool);
+
+    // Initial get, should subscribe and register listener
+    await cache.get("tripA");
+    expect(fakeClient.listenerCount("remoteOp")).toBe(1);
+
+    // Invalidate, should unregister listener
+    cache.invalidate("tripA");
+    expect(fakeClient.listenerCount("remoteOp")).toBe(0);
+  });
+
+  it("handles multiple get/invalidate cycles without leaking listeners", async () => {
+    const fakeClient = new FakeShareDBClient();
+    const fakeRest = {
+      getTripWithResources: async () => ({ geos: [] }),
+    } as unknown as RestClient;
+
+    const fakePool = {
+      get: () => fakeClient,
+    } as unknown as ShareDBPool;
+
+    const cache = new TripCache(fakeRest, fakePool);
+
+    for (let i = 0; i < 5; i++) {
+      await cache.get("tripA");
+      expect(fakeClient.listenerCount("remoteOp")).toBe(1);
+      cache.invalidate("tripA");
+      expect(fakeClient.listenerCount("remoteOp")).toBe(0);
+    }
+  });
+
+  it("unregisters listener on clear", async () => {
+    const fakeClient1 = new FakeShareDBClient();
+    const fakeClient2 = new FakeShareDBClient();
+    const fakeRest = {
+      getTripWithResources: async () => ({ geos: [] }),
+    } as unknown as RestClient;
+
+    const fakePool = {
+      get: (tripKey: string) => (tripKey === "tripA" ? fakeClient1 : fakeClient2),
+    } as unknown as ShareDBPool;
+
+    const cache = new TripCache(fakeRest, fakePool);
+
+    await cache.get("tripA");
+    await cache.get("tripB");
+
+    expect(fakeClient1.listenerCount("remoteOp")).toBe(1);
+    expect(fakeClient2.listenerCount("remoteOp")).toBe(1);
+
+    cache.clear();
+
+    expect(fakeClient1.listenerCount("remoteOp")).toBe(0);
+    expect(fakeClient2.listenerCount("remoteOp")).toBe(0);
+  });
+});


### PR DESCRIPTION
This pull request fixes a memory and event listener leak in `TripCache` by properly unregistering the `"remoteOp"` callback on cache invalidation or clear.

### Changes
- Track the registered listener callback reference in the `CacheEntry` object.
- Introduce `deleteEntry(tripKey)` to cleanly call `client.off("remoteOp", listener)` before deleting the entry from the cache map.
- Added corresponding unit tests verifying that callbacks are fully unregistered on invalidation or cache clear.