### PR TITLE
fix: populate block.imageKeys so places show photos on iOS/iPadOS (#10)

### DIFF
--- a/src/tools/add-hotel.ts
+++ b/src/tools/add-hotel.ts
@@ -80,6 +80,7 @@ export async function addHotel(
       );
     }
     const detail: PlaceData = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
+    const imageKeys = await ctx.rest.getPlacePhotos(detail);
 
     const block = buildPlaceBlock(detail, userId, {
       hotel: {
@@ -91,13 +92,11 @@ export async function addHotel(
     });
 
     const existing = findHotelsSection(trip);
+    const blockPath = existing
+      ? ["itinerary", "sections", existing.index, "blocks", existing.section.blocks.length]
+      : ["itinerary", "sections", 1, "blocks", 0];
     const ops: Json0Op[] = existing
-      ? [
-          {
-            p: ["itinerary", "sections", existing.index, "blocks", existing.section.blocks.length],
-            li: block,
-          },
-        ]
+      ? [{ p: blockPath, li: block }]
       : [
           {
             // Insert a new hotels section after the Notes section (index 1).
@@ -116,6 +115,9 @@ export async function addHotel(
             },
           },
         ];
+    if (imageKeys.length > 0) {
+      ops.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
+    }
 
     await submitOp(ctx, args.trip_key, ops);
 

--- a/src/tools/add-place.ts
+++ b/src/tools/add-place.ts
@@ -135,6 +135,7 @@ export async function addPlace(
     }
     const topPrediction = predictions[0]!;
     const detail: PlaceData = await ctx.rest.getPlaceDetails(topPrediction.place_id);
+    const imageKeys = await ctx.rest.getPlacePhotos(detail);
 
     // Build the block WITHOUT timing — timing is set via separate oi ops
     // to match the Wanderlog UI's two-step pattern (insert block, then set fields).
@@ -145,6 +146,11 @@ export async function addPlace(
     const ops: Json0Op[] = [
       { p: blockPath, li: block },
     ];
+    // iOS/iPadOS native apps render thumbnails strictly from `imageKeys`.
+    // Submit together with the `li` so no client ever sees a keyless block.
+    if (imageKeys.length > 0) {
+      ops.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
+    }
 
     await submitOp(ctx, args.trip_key, ops);
 

--- a/src/transport/rest.ts
+++ b/src/transport/rest.ts
@@ -157,6 +157,26 @@ export class RestClient {
     return env.data ?? [];
   }
 
+  /**
+   * Fetch Wanderlog-internal image keys for a place. The UI calls this before
+   * inserting a place block and stores the returned keys on `block.imageKeys`.
+   * Native apps (iOS/iPadOS) render images strictly from `imageKeys` — without
+   * them, the block shows no thumbnail. Returns [] on failure so callers can
+   * fall back to inserting the block without images.
+   */
+  async getPlacePhotos(place: PlaceData): Promise<string[]> {
+    try {
+      const env = await this.request<Envelope<{ data?: string[] }>>(
+        "POST",
+        `/api/placePhotos/${encodeURIComponent(place.place_id)}`,
+        { body: { place } },
+      );
+      return Array.isArray(env.data) ? env.data : [];
+    } catch {
+      return [];
+    }
+  }
+
   async getPlaceDetails(placeId: string, language = "en"): Promise<PlaceData> {
     const env = await this.request<Envelope<{ data?: PlaceData }>>(
       "GET",


### PR DESCRIPTION
## Summary

Fixes #10. Places added via the MCP rendered fine on wanderlog.com but appeared image-less in the iOS/iPadOS apps. A `place` block has two image surfaces: `place.photo_urls` (Google CDN URLs) and `block.imageKeys` (Wanderlog-internal storage IDs). The web client falls back to `photo_urls` when `imageKeys` is missing; the native apps render **strictly** from `imageKeys`.

This adds `RestClient.getPlacePhotos(place)` — `POST /api/placePhotos/{placeId}`, the same endpoint the web UI calls right before inserting a block — and threads the returned keys into `add_place` / `add_hotel`. The `imageKeys` are written via an `oi` op pushed into the **same** `submitOp` as the `li` block insert, so no client ever observes a keyless block (consistent with the documented pattern in `docs/api-reference.md` and `docs/gotchas.md`). On endpoint failure it returns `[]` so the block is still inserted without images rather than aborting the add.

Supersedes #16, which fixed the same issue via `GET /api/places/metadata`. Both endpoints return imageKeys, but this PR uses the documented UI flow, adds failure-fallback (so a thumbnail hiccup can't kill the add), and fetches only the key array rather than a heavy metadata blob.

### Invariants
- All mutations still go through `submitOp` (invariant 8); cache-on-failure unchanged (invariant 9).
- `imageKeys` are internal storage IDs set on the block, never surfaced to the LLM (invariant 2); REST envelope unwrapped as `{success, data}` (invariant 3).

## Test plan

- `npm run build` — clean.
- `npm run test` — 298 unit tests pass.
- Live verification against a known place (Eiffel Tower): `POST /api/placePhotos/{id}` returns 86 image keys; the op array carries them through to `block.imageKeys`.
- `npm run test:integration` — the new code path is exercised live (above); note 3 pre-existing integration files fail on a stale test-trip fixture (`Trip 'rrjhizy…' not found`) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)