### PR TITLE
feat: add add_section, update_section and delete_section tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2294,6 +2294,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2639,6 +2640,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4084,6 +4086,7 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4333,6 +4336,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2294,7 +2294,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2640,7 +2639,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4086,7 +4084,6 @@
       "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4336,7 +4333,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -130,6 +130,16 @@ import {
   removeJournalDescription,
   removeJournalInputSchema,
 } from "./tools/remove-journal.js";
+import {
+  addSection,
+  addSectionDescription,
+  addSectionInputSchema,
+} from "./tools/add-section.js";
+import {
+  updateSection,
+  updateSectionDescription,
+  updateSectionInputSchema,
+} from "./tools/update-section.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -478,6 +488,28 @@ export function buildServer(ctx: AppContext): McpServer {
     },
     requireAuth(ctx, async (args) =>
       removeJournal(ctx, args as Parameters<typeof removeJournal>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_add_section",
+    {
+      title: "Add a custom section to a Wanderlog trip",
+      description: addSectionDescription,
+      inputSchema: addSectionInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      addSection(ctx, args as Parameters<typeof addSection>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_update_section",
+    {
+      title: "Rename a custom section in a Wanderlog trip",
+      description: updateSectionDescription,
+      inputSchema: updateSectionInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      updateSection(ctx, args as Parameters<typeof updateSection>[1])),
   );
 
   return server;

--- a/src/server.ts
+++ b/src/server.ts
@@ -140,6 +140,11 @@ import {
   updateSectionDescription,
   updateSectionInputSchema,
 } from "./tools/update-section.js";
+import {
+  deleteSection,
+  deleteSectionDescription,
+  deleteSectionInputSchema,
+} from "./tools/delete-section.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -510,6 +515,17 @@ export function buildServer(ctx: AppContext): McpServer {
     },
     requireAuth(ctx, async (args) =>
       updateSection(ctx, args as Parameters<typeof updateSection>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_delete_section",
+    {
+      title: "Delete a custom section from a Wanderlog trip",
+      description: deleteSectionDescription,
+      inputSchema: deleteSectionInputSchema,
+    },
+    requireAuth(ctx, async (args) =>
+      deleteSection(ctx, args as Parameters<typeof deleteSection>[1])),
   );
 
   return server;

--- a/src/tools/add-place.ts
+++ b/src/tools/add-place.ts
@@ -8,6 +8,7 @@ import {
   buildPlaceBlock,
   findDaySectionByDate,
   findPlacesToVisitSection,
+  findSectionByRef,
   findTripCenter,
   requireUserId,
   submitOp,
@@ -30,6 +31,12 @@ export const addPlaceInputSchema = {
     .optional()
     .describe(
       "Optional day to add the place to. Accepts 'day 2', 'May 4', or ISO '2026-05-04'. Omit to add the place to the trip's 'Places to visit' list (unscheduled).",
+    ),
+  section: z
+    .string()
+    .optional()
+    .describe(
+      "Optional custom section to also add the place to, identified by its heading (e.g. 'Food & Drink', 'Must-See Spots'). Can be combined with 'day' to insert the place into both locations in a single call.",
     ),
   note: z
     .string()
@@ -68,6 +75,7 @@ type Args = {
   trip_key: string;
   place: string;
   day?: string;
+  section?: string;
   note?: string;
   start_time?: string;
   end_time?: string;
@@ -83,20 +91,32 @@ export async function addPlace(
     const entry = await ctx.tripCache.getEntry(args.trip_key);
     const trip = entry.snapshot;
 
-    // Resolve target section
-    let targetIndex: number;
-    let targetLabel: string;
+    // Resolve target sections. entry.snapshot is replaced after each submitOp
+    // (applyLocalOp returns a new object), so section indices are pre-computed
+    // once here — they stay stable because block inserts don't shift sections.
+    type Target = { sectionIndex: number; label: string };
+    const targets: Target[] = [];
+
     if (args.day) {
       const daySection = resolveDay(trip, args.day);
       const found = findDaySectionByDate(trip, daySection.date!);
       if (!found) {
+        throw new WanderlogValidationError(`Day ${args.day} not found in trip`);
+      }
+      targets.push({ sectionIndex: found.index, label: `day ${daySection.date}` });
+    }
+
+    if (args.section) {
+      const found = findSectionByRef(trip, args.section);
+      if (!found) {
         throw new WanderlogValidationError(
-          `Day ${args.day} not found in trip`,
+          `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
         );
       }
-      targetIndex = found.index;
-      targetLabel = `day ${daySection.date}`;
-    } else {
+      targets.push({ sectionIndex: found.index, label: `section "${args.section}"` });
+    }
+
+    if (targets.length === 0) {
       const places = findPlacesToVisitSection(trip);
       if (!places) {
         throw new WanderlogError(
@@ -105,8 +125,7 @@ export async function addPlace(
           "This is unexpected — Wanderlog usually creates one automatically. Try adding to a specific day instead.",
         );
       }
-      targetIndex = places.index;
-      targetLabel = "places to visit";
+      targets.push({ sectionIndex: places.index, label: "places to visit" });
     }
 
     const center = findTripCenter(trip, entry.geos);
@@ -139,56 +158,45 @@ export async function addPlace(
     const detail: PlaceData = await ctx.rest.getPlaceDetails(topPrediction.place_id);
     const imageKeys = await ctx.rest.getPlacePhotos(detail);
 
-    // Build the block WITHOUT timing — timing is set via separate oi ops
-    // to match the Wanderlog UI's two-step pattern (insert block, then set fields).
-    const block = buildPlaceBlock(detail, userId);
-    const section = trip.itinerary.sections[targetIndex]!;
-    const insertIndex = section.blocks.length;
-    const blockPath = ["itinerary", "sections", targetIndex, "blocks", insertIndex];
-    const ops: Json0Op[] = [
-      { p: blockPath, li: block },
-    ];
-    // iOS/iPadOS native apps render thumbnails strictly from `imageKeys`.
-    // Submit together with the `li` so no client ever sees a keyless block.
-    if (imageKeys.length > 0) {
-      ops.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
-    }
+    // Insert the place into each target. entry.snapshot is read fresh each
+    // iteration so blocks.length is accurate even when both targets are the
+    // same section (second block must go at N+1, not N).
+    for (const target of targets) {
+      const currentSnapshot = entry.snapshot;
+      const insertIndex = currentSnapshot.itinerary.sections[target.sectionIndex]!.blocks.length;
+      const blockPath = ["itinerary", "sections", target.sectionIndex, "blocks", insertIndex];
 
-    await submitOp(ctx, args.trip_key, ops);
-
-    // Follow-up: set inline note text via rich-text subtype op
-    if (args.note) {
-      const textOps: Json0Op[] = [
-        {
-          p: [...blockPath, "text"],
-          t: "rich-text",
-          o: [{ insert: `${args.note}\n` }],
-        },
-      ];
-      await submitOp(ctx, args.trip_key, textOps);
-    }
-
-    // Follow-up: set timing via plain oi ops. The block was inserted without
-    // timing fields, so we use oi (object insert) without od — the key doesn't
-    // exist yet. This matches the Wanderlog UI's two-step pattern.
-    if (args.start_time || args.end_time) {
-      const timeOps: Json0Op[] = [];
-      if (args.start_time) {
-        timeOps.push({
-          p: [...blockPath, "startTime"],
-          oi: args.start_time,
-        });
+      // Build the block WITHOUT timing — timing is set via separate oi ops
+      // to match the Wanderlog UI's two-step pattern (insert block, then set fields).
+      const block = buildPlaceBlock(detail, userId);
+      const insertOps: Json0Op[] = [{ p: blockPath, li: block }];
+      // iOS/iPadOS native apps render thumbnails strictly from `imageKeys`.
+      // Submit together with the `li` so no client ever sees a keyless block.
+      if (imageKeys.length > 0) {
+        insertOps.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
       }
-      if (args.end_time) {
-        timeOps.push({
-          p: [...blockPath, "endTime"],
-          oi: args.end_time,
-        });
+      await submitOp(ctx, args.trip_key, insertOps);
+
+      if (args.note) {
+        await submitOp(ctx, args.trip_key, [
+          {
+            p: [...blockPath, "text"],
+            t: "rich-text",
+            o: [{ insert: `${args.note}\n` }],
+          },
+        ]);
       }
-      await submitOp(ctx, args.trip_key, timeOps);
+
+      if (args.start_time || args.end_time) {
+        const timeOps: Json0Op[] = [];
+        if (args.start_time) timeOps.push({ p: [...blockPath, "startTime"], oi: args.start_time });
+        if (args.end_time) timeOps.push({ p: [...blockPath, "endTime"], oi: args.end_time });
+        await submitOp(ctx, args.trip_key, timeOps);
+      }
     }
 
-    const parts = [`Added ${detail.name} to ${targetLabel} in "${trip.title}".`];
+    const labelList = targets.map((t) => t.label).join(" and ");
+    const parts = [`Added ${detail.name} to ${labelList} in "${trip.title}".`];
     if (args.start_time) {
       parts.push(`Scheduled: ${args.start_time}${args.end_time ? `–${args.end_time}` : ""}.`);
     }

--- a/src/tools/add-section.ts
+++ b/src/tools/add-section.ts
@@ -34,8 +34,8 @@ notes, and other blocks — use them to group content thematically (e.g. "Food &
 "Day Trips", "Must-See Spots") or to create additional place lists beyond the default
 "Places to visit".
 
-The new section is empty; add places to it with wanderlog_add_place using the section heading
-as the "day" reference, or use wanderlog_add_note / wanderlog_add_checklist.
+The new section is empty; add places to it with wanderlog_add_place by passing the section
+heading as the "section" parameter, or use wanderlog_add_note / wanderlog_add_checklist.
 
 Returns the heading and position of the inserted section.
 `.trim();

--- a/src/tools/add-section.ts
+++ b/src/tools/add-section.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogValidationError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import {
+  buildSectionObject,
+  findSectionByRef,
+  requireUserId,
+  submitOp,
+} from "./shared.js";
+
+export const addSectionInputSchema = {
+  trip_key: z
+    .string()
+    .min(1)
+    .describe("The trip to add the section to. Use wanderlog_list_trips if you don't know the key."),
+  heading: z
+    .string()
+    .optional()
+    .describe(
+      "Heading for the new section (e.g. 'Food & Drink', 'Must-See Spots'). Omit for an untitled section.",
+    ),
+  after_section: z
+    .string()
+    .optional()
+    .describe(
+      "Insert the new section immediately after an existing section identified by its heading (e.g. 'Places to visit', 'Food & Drink'). Omit to append at the end of the trip.",
+    ),
+};
+
+export const addSectionDescription = `
+Adds a new custom section to a Wanderlog trip itinerary. Sections are containers for places,
+notes, and other blocks — use them to group content thematically (e.g. "Food & Drink",
+"Day Trips", "Must-See Spots") or to create additional place lists beyond the default
+"Places to visit".
+
+The new section is empty; add places to it with wanderlog_add_place using the section heading
+as the "day" reference, or use wanderlog_add_note / wanderlog_add_checklist.
+
+Returns the heading and position of the inserted section.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  heading?: string;
+  after_section?: string;
+};
+
+export async function addSection(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    requireUserId(ctx);
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    let insertIndex: number;
+    if (args.after_section) {
+      const found = findSectionByRef(trip, args.after_section);
+      if (!found) {
+        throw new WanderlogValidationError(
+          `Section "${args.after_section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+        );
+      }
+      insertIndex = found.index + 1;
+    } else {
+      insertIndex = trip.itinerary.sections.length;
+    }
+
+    const heading = args.heading ?? "";
+    const section = buildSectionObject(heading);
+
+    const ops: Json0Op[] = [
+      { p: ["itinerary", "sections", insertIndex], li: section },
+    ];
+    await submitOp(ctx, args.trip_key, ops);
+
+    const headingLabel = heading || "(untitled)";
+    const positionLabel = args.after_section
+      ? `after "${args.after_section}"`
+      : "at the end";
+    const text = `Added section "${headingLabel}" ${positionLabel} in "${trip.title}".`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/delete-section.ts
+++ b/src/tools/delete-section.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogValidationError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import {
+  findPlacesToVisitSection,
+  findSectionByRef,
+  submitOp,
+} from "./shared.js";
+
+export const deleteSectionInputSchema = {
+  trip_key: z
+    .string()
+    .min(1)
+    .describe("The trip to delete the section from."),
+  section: z
+    .string()
+    .min(1)
+    .describe(
+      "The section to delete, identified by its heading (e.g. 'Food & Drink'). Use wanderlog_get_trip to see available sections.",
+    ),
+};
+
+export const deleteSectionDescription = `
+Deletes a custom section from a Wanderlog trip itinerary. The section and all blocks inside it
+are permanently removed.
+
+Only custom sections (created via wanderlog_add_section or the Wanderlog UI) can be deleted.
+Day sections, the default "Places to visit" list, and system sections (hotels, flights, transit)
+are protected and cannot be removed with this tool.
+
+Returns a confirmation with the deleted section's heading.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  section: string;
+};
+
+const SYSTEM_SECTION_TYPES = new Set(["hotels", "flights", "transit"]);
+
+export async function deleteSection(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    const found = findSectionByRef(trip, args.section);
+    if (!found) {
+      throw new WanderlogValidationError(
+        `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+      );
+    }
+
+    const { index, section } = found;
+
+    if (section.mode === "dayPlan") {
+      throw new WanderlogValidationError(
+        `Day sections cannot be deleted here. Use wanderlog_update_trip_dates to change the trip's date range instead.`,
+      );
+    }
+
+    if (findPlacesToVisitSection(trip)?.index === index) {
+      throw new WanderlogValidationError(
+        `The "Places to visit" section cannot be deleted — it is the trip's default place list.`,
+      );
+    }
+
+    if (SYSTEM_SECTION_TYPES.has(section.type)) {
+      throw new WanderlogValidationError(
+        `The "${section.heading || section.type}" section is a system section and cannot be deleted.`,
+      );
+    }
+
+    const ops: Json0Op[] = [
+      { p: ["itinerary", "sections", index], ld: section },
+    ];
+    await submitOp(ctx, args.trip_key, ops);
+
+    const label = section.heading || "(untitled)";
+    const text = `Deleted section "${label}" from "${trip.title}".`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -96,9 +96,51 @@ async function submitWithRateLimitRetry(
   }
 }
 
-/** Wanderlog block IDs are 9-digit numeric. */
+/** Wanderlog block IDs are 9-digit numeric. Sections use the same format. */
 export function generateBlockId(): number {
   return Math.floor(Math.random() * 1_000_000_000);
+}
+
+/**
+ * Build a new custom section matching the shape Wanderlog inserts from its UI.
+ * Always type "normal" / mode "placeList" — day sections are managed by update-trip-dates.
+ */
+export function buildSectionObject(heading: string): Section {
+  return {
+    id: generateBlockId(),
+    type: "normal",
+    mode: "placeList",
+    heading,
+    date: null,
+    blocks: [],
+    text: { ops: [{ insert: "\n" }] },
+    placeMarkerColor: "#3498db",
+    placeMarkerIcon: "map-marker",
+  };
+}
+
+/**
+ * Resolves a natural-language section reference to its index and Section object.
+ * Resolution order:
+ *   1. "places to visit" / "places" → the default placeList section (via findPlacesToVisitSection)
+ *   2. Case-insensitive heading match across all sections
+ * Returns null when no section matches.
+ */
+export function findSectionByRef(
+  trip: TripPlan,
+  ref: string,
+): { index: number; section: Section } | null {
+  const normalized = ref.trim().toLowerCase();
+  if (normalized === "places to visit" || normalized === "places") {
+    return findPlacesToVisitSection(trip);
+  }
+  for (let i = 0; i < trip.itinerary.sections.length; i++) {
+    const s = trip.itinerary.sections[i]!;
+    if (s.heading.trim().toLowerCase() === normalized) {
+      return { index: i, section: s };
+    }
+  }
+  return null;
 }
 
 export function requireUserId(ctx: AppContext): number {

--- a/src/tools/update-section.ts
+++ b/src/tools/update-section.ts
@@ -1,0 +1,91 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError, WanderlogValidationError } from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import { findSectionByRef, submitOp } from "./shared.js";
+
+export const updateSectionInputSchema = {
+  trip_key: z
+    .string()
+    .min(1)
+    .describe("The trip containing the section to update."),
+  section: z
+    .string()
+    .min(1)
+    .describe(
+      "The section to update, identified by its current heading (e.g. 'Food & Drink', 'Places to visit'). Use wanderlog_get_trip to see available sections.",
+    ),
+  heading: z
+    .string()
+    .describe(
+      'New heading for the section. Pass "" (empty string) to clear it back to an untitled section.',
+    ),
+};
+
+export const updateSectionDescription = `
+Renames the heading of a custom section in a Wanderlog trip.
+
+Identify the section by its current heading. Use wanderlog_get_trip to see all sections and
+their current headings if you are unsure. Pass an empty string for "heading" to clear the
+section title.
+
+Returns a confirmation showing the old and new heading.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  section: string;
+  heading: string;
+};
+
+export async function updateSection(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    const found = findSectionByRef(trip, args.section);
+    if (!found) {
+      throw new WanderlogValidationError(
+        `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+      );
+    }
+
+    const oldHeading = found.section.heading;
+    const newHeading = args.heading;
+
+    if (oldHeading === newHeading) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Section heading is already "${newHeading || "(untitled)"}" — no change made.`,
+          },
+        ],
+      };
+    }
+
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", found.index, "heading"],
+        od: oldHeading,
+        oi: newHeading,
+      },
+    ];
+
+    await submitOp(ctx, args.trip_key, ops);
+
+    const oldLabel = oldHeading || "(untitled)";
+    const newLabel = newHeading || "(untitled)";
+    const text = `Renamed section "${oldLabel}" → "${newLabel}" in "${trip.title}".`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/update-section.ts
+++ b/src/tools/update-section.ts
@@ -2,7 +2,11 @@ import { z } from "zod";
 import type { AppContext } from "../context.js";
 import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
-import { findSectionByRef, submitOp } from "./shared.js";
+import {
+  findPlacesToVisitSection,
+  findSectionByRef,
+  submitOp,
+} from "./shared.js";
 
 export const updateSectionInputSchema = {
   trip_key: z
@@ -38,6 +42,8 @@ type Args = {
   heading: string;
 };
 
+const SYSTEM_SECTION_TYPES = new Set(["hotels", "flights", "transit"]);
+
 export async function updateSection(
   ctx: AppContext,
   args: Args,
@@ -50,6 +56,26 @@ export async function updateSection(
     if (!found) {
       throw new WanderlogValidationError(
         `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+      );
+    }
+
+    const { index, section } = found;
+
+    if (section.mode === "dayPlan") {
+      throw new WanderlogValidationError(
+        `Day sections cannot be renamed here. Use wanderlog_rename_day to change a day's heading instead.`,
+      );
+    }
+
+    if (findPlacesToVisitSection(trip)?.index === index) {
+      throw new WanderlogValidationError(
+        `The "Places to visit" section cannot be renamed — it is the trip's default place list. Use wanderlog_get_trip to see your custom sections.`,
+      );
+    }
+
+    if (SYSTEM_SECTION_TYPES.has(section.type)) {
+      throw new WanderlogValidationError(
+        `The "${section.heading || section.type}" section is a system section and cannot be renamed. Use wanderlog_get_trip to see your custom sections.`,
       );
     }
 

--- a/tests/unit/add-update-section.test.ts
+++ b/tests/unit/add-update-section.test.ts
@@ -1,14 +1,40 @@
 import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
 import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
 import {
   buildSectionObject,
   findSectionByRef,
 } from "../../src/tools/shared.ts";
+import { updateSection } from "../../src/tools/update-section.ts";
 import type { Section, TripPlan } from "../../src/types.ts";
 import { checklistTrip } from "../fixtures/checklist-trip.ts";
 
 function fresh(trip: TripPlan): TripPlan {
   return structuredClone(trip);
+}
+
+function makeFakeContext(trip: TripPlan): {
+  ctx: AppContext;
+  submittedOps: Json0Op[][];
+} {
+  const submittedOps: Json0Op[][] = [];
+  const ctx = {
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      getEntry: async () => ({ snapshot: structuredClone(trip) }),
+      applyLocalOp: () => {},
+      invalidate: () => {},
+    },
+  } as unknown as AppContext;
+  return { ctx, submittedOps };
 }
 
 // ---------------------------------------------------------------------------
@@ -193,5 +219,52 @@ describe("applyOp – section ld", () => {
       { p: ["itinerary", "sections", 0], ld: staleSection },
     ];
     expect(() => applyOp(doc, ops)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// updateSection guards — must refuse day/places-to-visit/system sections,
+// mirroring deleteSection so it can't collide with rename_day or corrupt
+// the day structure.
+// ---------------------------------------------------------------------------
+
+describe("updateSection guards", () => {
+  it("refuses to rename a day (dayPlan) section and points at rename_day", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const res = await updateSection(ctx, {
+      trip_key: "T",
+      section: "Arrival day",
+      heading: "Renamed day",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("rename_day");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("refuses to rename the 'Places to visit' default list", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const res = await updateSection(ctx, {
+      trip_key: "T",
+      section: "Places to visit",
+      heading: "My places",
+    });
+    expect(res.isError).toBe(true);
+    expect(res.content[0]!.text).toContain("default place list");
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("allows renaming a genuine custom section", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const res = await updateSection(ctx, {
+      trip_key: "T",
+      section: "Notes",
+      heading: "Trip Notes",
+    });
+    expect(res.isError).toBeUndefined();
+    expect(submittedOps).toHaveLength(1);
+    expect(submittedOps[0]![0]!).toMatchObject({
+      od: "Notes",
+      oi: "Trip Notes",
+    });
   });
 });

--- a/tests/unit/add-update-section.test.ts
+++ b/tests/unit/add-update-section.test.ts
@@ -166,3 +166,32 @@ describe("applyOp – section heading od+oi", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// applyOp round-trip: section list delete (ld)
+// ---------------------------------------------------------------------------
+
+describe("applyOp – section ld", () => {
+  it("removes a section and shifts remaining sections", () => {
+    const doc = fresh(checklistTrip);
+    const sectionCount = doc.itinerary.sections.length;
+    // Delete the section at index 0 ("Notes")
+    const target = doc.itinerary.sections[0]!;
+    const ops: Json0Op[] = [
+      { p: ["itinerary", "sections", 0], ld: target },
+    ];
+    const next = applyOp(doc, ops);
+    expect(next.itinerary.sections).toHaveLength(sectionCount - 1);
+    // Former index 1 ("Places to visit") is now at index 0
+    expect((next.itinerary.sections[0]! as Section).heading).toBe("Places to visit");
+  });
+
+  it("throws when ld value does not match the existing section", () => {
+    const doc = fresh(checklistTrip);
+    const staleSection = { ...doc.itinerary.sections[0]!, heading: "Wrong heading" };
+    const ops: Json0Op[] = [
+      { p: ["itinerary", "sections", 0], ld: staleSection },
+    ];
+    expect(() => applyOp(doc, ops)).toThrow();
+  });
+});

--- a/tests/unit/add-update-section.test.ts
+++ b/tests/unit/add-update-section.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import {
+  buildSectionObject,
+  findSectionByRef,
+} from "../../src/tools/shared.ts";
+import type { Section, TripPlan } from "../../src/types.ts";
+import { checklistTrip } from "../fixtures/checklist-trip.ts";
+
+function fresh(trip: TripPlan): TripPlan {
+  return structuredClone(trip);
+}
+
+// ---------------------------------------------------------------------------
+// buildSectionObject
+// ---------------------------------------------------------------------------
+
+describe("buildSectionObject", () => {
+  it("produces the correct shape with a heading", () => {
+    const s = buildSectionObject("Food & Drink");
+    expect(s.type).toBe("normal");
+    expect(s.mode).toBe("placeList");
+    expect(s.heading).toBe("Food & Drink");
+    expect(s.date).toBeNull();
+    expect(s.blocks).toEqual([]);
+    expect(s.text).toEqual({ ops: [{ insert: "\n" }] });
+    expect(s.placeMarkerColor).toBe("#3498db");
+    expect(s.placeMarkerIcon).toBe("map-marker");
+    expect(typeof s.id).toBe("number");
+    expect(s.id).toBeGreaterThanOrEqual(0);
+    expect(s.id).toBeLessThan(1_000_000_000);
+  });
+
+  it("accepts an empty heading", () => {
+    const s = buildSectionObject("");
+    expect(s.heading).toBe("");
+  });
+
+  it("generates unique IDs across calls", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => buildSectionObject("X").id));
+    expect(ids.size).toBeGreaterThan(45);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findSectionByRef
+// ---------------------------------------------------------------------------
+
+describe("findSectionByRef", () => {
+  it("finds 'places to visit' alias", () => {
+    const trip = fresh(checklistTrip);
+    const result = findSectionByRef(trip, "places to visit");
+    expect(result).not.toBeNull();
+    expect(result!.section.heading).toBe("Places to visit");
+  });
+
+  it("finds 'places' alias (short form)", () => {
+    const trip = fresh(checklistTrip);
+    const result = findSectionByRef(trip, "places");
+    expect(result).not.toBeNull();
+    expect(result!.section.heading).toBe("Places to visit");
+  });
+
+  it("finds a section by its exact heading", () => {
+    const trip = fresh(checklistTrip);
+    const result = findSectionByRef(trip, "Notes");
+    expect(result).not.toBeNull();
+    expect(result!.section.heading).toBe("Notes");
+    expect(result!.index).toBe(0);
+  });
+
+  it("matches heading case-insensitively", () => {
+    const trip = fresh(checklistTrip);
+    const result = findSectionByRef(trip, "notes");
+    expect(result).not.toBeNull();
+    expect(result!.index).toBe(0);
+  });
+
+  it("returns null for an unknown reference", () => {
+    const trip = fresh(checklistTrip);
+    expect(findSectionByRef(trip, "Nonexistent Section")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyOp round-trip: section list insert (li)
+// ---------------------------------------------------------------------------
+
+describe("applyOp – section li", () => {
+  it("inserts a new section at the end", () => {
+    const doc = fresh(checklistTrip);
+    const section = buildSectionObject("Day Trips");
+    const insertIndex = doc.itinerary.sections.length;
+    const ops: Json0Op[] = [
+      { p: ["itinerary", "sections", insertIndex], li: section },
+    ];
+    const next = applyOp(doc, ops);
+    expect(next.itinerary.sections).toHaveLength(insertIndex + 1);
+    const inserted = next.itinerary.sections[insertIndex]! as Section;
+    expect(inserted.heading).toBe("Day Trips");
+    expect(inserted.type).toBe("normal");
+    expect(inserted.mode).toBe("placeList");
+    expect(inserted.blocks).toEqual([]);
+  });
+
+  it("inserts a section at a mid-trip position", () => {
+    const doc = fresh(checklistTrip);
+    const section = buildSectionObject("Must-See");
+    const ops: Json0Op[] = [
+      { p: ["itinerary", "sections", 1], li: section },
+    ];
+    const next = applyOp(doc, ops);
+    expect((next.itinerary.sections[1]! as Section).heading).toBe("Must-See");
+    // Existing section at index 1 is shifted to index 2
+    expect((next.itinerary.sections[2]! as Section).heading).toBe("Places to visit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyOp round-trip: section heading update (od + oi)
+// ---------------------------------------------------------------------------
+
+describe("applyOp – section heading od+oi", () => {
+  it("updates a section heading in place", () => {
+    const doc = fresh(checklistTrip);
+    // Section at index 0 has heading "Notes"
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", 0, "heading"],
+        od: "Notes",
+        oi: "Trip Notes",
+      },
+    ];
+    const next = applyOp(doc, ops);
+    expect((next.itinerary.sections[0]! as Section).heading).toBe("Trip Notes");
+    // Other fields on the section should be unchanged
+    expect(next.itinerary.sections[0]!.id).toBe(doc.itinerary.sections[0]!.id);
+  });
+
+  it("clears a heading to empty string", () => {
+    const doc = fresh(checklistTrip);
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", 0, "heading"],
+        od: "Notes",
+        oi: "",
+      },
+    ];
+    const next = applyOp(doc, ops);
+    expect((next.itinerary.sections[0]! as Section).heading).toBe("");
+  });
+
+  it("does not affect sibling sections", () => {
+    const doc = fresh(checklistTrip);
+    const ops: Json0Op[] = [
+      {
+        p: ["itinerary", "sections", 0, "heading"],
+        od: "Notes",
+        oi: "Renamed",
+      },
+    ];
+    const next = applyOp(doc, ops);
+    // Section at index 1 ("Places to visit") must be untouched
+    expect((next.itinerary.sections[1]! as Section).heading).toBe(
+      doc.itinerary.sections[1]!.heading,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #11 

## Summary

Adds two new tools for managing custom sections in Wanderlog trips: `wanderlog_add_section` (create new sections with optional positioning) and `wanderlog_update_section` (rename existing sections). Also refactors `wanderlog_add_place` to support adding places to custom sections in addition to days, and extracts shared section utilities (`buildSectionObject`, `findSectionByRef`) into `src/tools/shared.ts` for reuse.

## Test plan

Added comprehensive unit tests in `tests/unit/add-update-section.test.ts` covering:
- `buildSectionObject`: shape validation, unique ID generation, empty heading support
- `findSectionByRef`: alias resolution ("places to visit" / "places"), case-insensitive heading matching, null return for unknown sections
- `applyOp` round-trips: section insertion via `li` op, heading updates via `od`/`oi` ops, sibling isolation

Verified `wanderlog_add_place` refactor maintains existing behavior while adding section support:
- Existing day-based and default "places to visit" flows unchanged
- New section parameter works independently or combined with day parameter
- Multiple targets (day + section) insert into both locations in a single call

## Agent-facing surface changes

- [x] Changed a tool description, parameter doc, or error message
      - Added `section` parameter to `wanderlog_add_place` with clear documentation
      - New tool descriptions for `wanderlog_add_section`, `wanderlog_update_section` and `wanderlog_delete_section`
      - Error messages reference `wanderlog_get_trip` for section discovery (natural language, no IDs exposed)