### PR TITLE
fix: derive MCP server version from package.json instead of hardcoding

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { AppContext } from "./context.js";
+import { VERSION } from "./version.js";
 import {
   addChecklist,
   addChecklistDescription,
@@ -224,7 +225,7 @@ JOURNALING (a trip's travelogue of places the user actually visited):
 
 export function buildServer(ctx: AppContext): McpServer {
   const server = new McpServer(
-    { name: "wanderlog-mcp", version: "0.3.2" },
+    { name: "wanderlog-mcp", version: VERSION },
     { instructions: SERVER_INSTRUCTIONS },
   );
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * The package version, read from package.json at runtime.
+ *
+ * This used to be a string literal in `buildServer()`, which meant every release
+ * had to remember to bump it in two places. It drifted: v0.3.0 and v0.3.1 both
+ * shipped announcing `0.2.0` in the MCP handshake, because the release bumped
+ * package.json and left the literal behind.
+ *
+ * `../package.json` resolves from both `src/version.ts` (dev, via tsx) and
+ * `dist/version.js` (published), because tsconfig maps `src/*` to `dist/*`
+ * flatly. A static `import pkg from "../package.json"` would be tidier, but
+ * package.json sits outside `rootDir: ./src`, so TypeScript would re-root the
+ * emit to `dist/src/*` and break the `bin`/`exports` paths.
+ *
+ * npm always includes package.json in the published tarball, so this is
+ * available at runtime regardless of the `files` allowlist.
+ */
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version?: unknown };
+
+if (typeof pkg.version !== "string" || pkg.version.length === 0) {
+  throw new Error("Could not read a version string from package.json");
+}
+
+export const VERSION: string = pkg.version;

--- a/tests/unit/version.test.ts
+++ b/tests/unit/version.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { VERSION } from "../../src/version.js";
+
+/**
+ * Regression guard for the MCP handshake version.
+ *
+ * v0.3.0 and v0.3.1 both shipped announcing "0.2.0" over MCP, because the
+ * version was a literal in server.ts that release bumps didn't touch. It is now
+ * derived from package.json; these tests fail if that derivation breaks.
+ */
+describe("VERSION", () => {
+  const pkg = JSON.parse(
+    readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+  ) as { version: string };
+
+  it("matches the version in package.json", () => {
+    expect(VERSION).toBe(pkg.version);
+  });
+
+  it("is a non-empty semver string", () => {
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("is not hardcoded anywhere in server.ts", () => {
+    // The specific mistake being guarded against: a literal version string
+    // passed to the McpServer constructor, which then silently goes stale.
+    const source = readFileSync(new URL("../../src/server.ts", import.meta.url), "utf8");
+    expect(source).not.toMatch(/name:\s*"wanderlog-mcp",\s*version:\s*"/);
+  });
+});


### PR DESCRIPTION
## Summary

The version reported in the MCP `initialize` handshake was a string literal in `buildServer()`,
duplicating `package.json`. It drifted — **v0.3.0 and v0.3.1 both shipped announcing `0.2.0`** to
every connected client, because the release bumped `package.json` and left the literal behind:

| Tag | `package.json` | `serverInfo.version` |
|---|---|---|
| v0.2.0 | 0.2.0 | 0.2.0 ✅ |
| v0.3.0 | 0.3.0 | **0.2.0** ❌ |
| v0.3.1 | 0.3.1 | **0.2.0** ❌ |

`main` currently reads `0.3.2`, so the literal has been corrected by hand at least once — which is
exactly the pattern that drifts again on the next release.

This is more than cosmetic: `serverInfo.version` is how clients identify the server. Anything that
inspects the handshake — logging, telemetry, update tooling, bug reports — sees the wrong version.
I hit this running an update checker: it reported "updated to 0.3.1" beside "server reports 0.2.0",
which looks precisely like a failed deployment.

The fix derives the version from `package.json` at runtime, so the two cannot diverge.

Note the deliberate choice of `readFileSync(new URL(...))` over a static
`import pkg from "../package.json"`: `package.json` sits outside `rootDir: ./src`, so a static
import re-roots the emit to `dist/src/*` and breaks the `bin` path. The relative path resolves
identically from `src/version.ts` under `tsx` and `dist/version.js` when published, and npm always
includes `package.json` in the tarball regardless of the `files` allowlist. This is explained in a
comment so the next person doesn't "simplify" it back into a broken build.

## Test plan

New `tests/unit/version.test.ts` asserts `VERSION` matches `package.json`, is valid semver, and
that no version literal has been reintroduced into the `McpServer` constructor.

Verified locally on Node v24:

- `npm run typecheck` — clean
- `npm run lint` — no new warnings (`npx eslint src/version.ts tests/unit/version.test.ts` is clean;
  the 35 pre-existing warnings are unchanged)
- `npm test` — **391 passed / 30 files**, including the 3 new assertions
- `npm run build` — `dist/` layout unchanged and flat; `dist/version.js` emitted, no `dist/src/`

Beyond CI:

- **Built-artifact check.** Imported `dist/version.js` as published and confirmed it reports
  `0.3.2`, matching `package.json` — i.e. the path resolves correctly post-compile, not just under
  `tsx`.
- **Drift check.** Bumped `package.json` to `9.9.9-drifttest` *without touching any source*;
  `dist/version.js` immediately reported `9.9.9-drifttest`. Under the old code this required a
  manual edit, which is the whole bug. Restored afterwards.
- **Mutation check on the guard.** Reintroduced the exact original line
  (`version: "0.2.0"`) and confirmed the new test fails; restored and confirmed it passes. The
  regression test has teeth rather than being tautological.

I did not run `test:integration` or `eval`, as both need live Wanderlog credentials.
