### PR TITLE
fix: prevent own-op double-apply on retry and refetch stale snapshot …

### DIFF
--- a/src/cache/trip-cache.ts
+++ b/src/cache/trip-cache.ts
@@ -98,10 +98,15 @@ export class TripCache {
   private deleteEntry(tripKey: string): void {
     const entry = this.entries.get(tripKey);
     if (entry) {
+      const client = this.pool.get(tripKey);
       if (entry.listener) {
-        const client = this.pool.get(tripKey);
         client.off("remoteOp", entry.listener);
       }
+      // Drop the client's frozen snapshot too, otherwise the next get() would
+      // re-subscribe and receive the stale in-memory copy instead of refetching
+      // fresh server state (invariant: a failed submit invalidates the cache so
+      // the next read sees a fresh snapshot).
+      client.discardSnapshot();
       this.entries.delete(tripKey);
     }
   }

--- a/src/transport/sharedb.ts
+++ b/src/transport/sharedb.ts
@@ -253,17 +253,25 @@ export class ShareDBClient extends EventEmitter {
   }
 
   private handleOpFrame(frame: OpFrame): void {
-    const isOurAck =
-      frame.src === this.sessionId &&
-      frame.seq !== undefined &&
-      this.pendingOps.has(frame.seq);
+    // Ops we authored echo back with src === our session id. They must never
+    // travel the remoteOp path: we already applied them locally when we
+    // submitted, so replaying them would double-apply the mutation and create
+    // duplicate blocks. This matters even when no pending entry matches — a
+    // late ack arriving after the 10s submit timeout, or a duplicate ack from a
+    // rate-limit retry, both echo our own src with a seq we've already cleared.
+    const isOurs = frame.src !== undefined && frame.src === this.sessionId;
 
-    if (isOurAck) {
-      const pending = this.pendingOps.get(frame.seq!)!;
-      this.pendingOps.delete(frame.seq!);
-      clearTimeout(pending.timer);
-      this._version = frame.v + 1;
-      pending.resolve();
+    if (isOurs) {
+      if (frame.seq !== undefined && this.pendingOps.has(frame.seq)) {
+        const pending = this.pendingOps.get(frame.seq)!;
+        this.pendingOps.delete(frame.seq);
+        clearTimeout(pending.timer);
+        this._version = frame.v + 1;
+        pending.resolve();
+      }
+      // Own op with no matching pending entry (late/duplicate ack): already
+      // applied and accounted for. Drop it without re-emitting or rewinding the
+      // version — the correct version is re-synced on the next fresh subscribe.
       return;
     }
 
@@ -356,6 +364,21 @@ export class ShareDBClient extends EventEmitter {
     this._version = ack.data.v;
     this.subscribed = true;
     return this.snapshot;
+  }
+
+  /**
+   * Forget the cached snapshot so the next subscribe() re-requests it from the
+   * server instead of returning the stale in-memory copy. The client's snapshot
+   * is frozen at first subscribe (ops flow through the trip cache, not here), so
+   * without this a post-invalidation read would resurrect stale data. The trip
+   * cache calls this when it drops an entry — e.g. after a failed submit — so
+   * the next read is guaranteed to see fresh server state. The WebSocket stays
+   * open; we only reset subscription bookkeeping, mirroring the post-reconnect
+   * resubscribe path.
+   */
+  discardSnapshot(): void {
+    this.subscribed = false;
+    this.snapshot = undefined;
   }
 
   /**

--- a/tests/unit/rate-limit-retry.test.ts
+++ b/tests/unit/rate-limit-retry.test.ts
@@ -178,3 +178,96 @@ describe("ShareDBClient bare {code, message} rejection frames", () => {
     expect(client.version).toBe(8);
   });
 });
+
+describe("ShareDBClient own-op idempotency", () => {
+  const config = {
+    cookieHeader: "connect.sid=test",
+    baseUrl: "https://example.test",
+    wsBaseUrl: "wss://example.test",
+    userAgent: "test",
+  };
+
+  function deliverFrame(client: ShareDBClient, frame: Record<string, unknown>) {
+    (
+      client as unknown as {
+        handleFrame: (
+          frame: Record<string, unknown>,
+          handshakeTimeout: NodeJS.Timeout,
+          connectResolve: () => void,
+        ) => void;
+      }
+    ).handleFrame(frame, setTimeout(() => {}, 60_000), () => {});
+  }
+
+  it("does not re-emit an op we authored when no pending entry matches", () => {
+    // Reproduces the double-apply bug: a late ack (its submit already timed out)
+    // or a duplicate ack from a rate-limit retry echoes our own src with a seq
+    // we've already cleared. It must NOT surface as a remoteOp — the cache
+    // already applied it once, and replaying it duplicates the mutation.
+    const client = new ShareDBClient(config, "tripA");
+    const internals = client as unknown as { sessionId?: string; _version: number };
+    internals.sessionId = "me";
+    internals._version = 3;
+
+    let remoteOps = 0;
+    client.on("remoteOp", () => {
+      remoteOps++;
+    });
+
+    deliverFrame(client, {
+      a: "op",
+      src: "me",
+      seq: 99, // no pending entry with this seq
+      v: 2,
+      op: [{ p: ["days"], oi: 5 }],
+      c: "TripPlans",
+      d: "tripA",
+    });
+
+    expect(remoteOps).toBe(0);
+    // Version must not rewind below the value newer ops already advanced it to.
+    expect(client.version).toBe(3);
+  });
+
+  it("still emits genuine remote ops from other sessions", () => {
+    const client = new ShareDBClient(config, "tripA");
+    const internals = client as unknown as { sessionId?: string };
+    internals.sessionId = "me";
+
+    const seen: Array<{ ops: unknown; version: number }> = [];
+    client.on("remoteOp", (ops, version) => {
+      seen.push({ ops, version });
+    });
+
+    deliverFrame(client, {
+      a: "op",
+      src: "someone-else",
+      v: 10,
+      op: [{ p: ["days"], oi: 7 }],
+      c: "TripPlans",
+      d: "tripA",
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.version).toBe(11);
+    expect(client.version).toBe(11);
+  });
+
+  it("discardSnapshot forces the next subscribe to refetch", () => {
+    const client = new ShareDBClient(config, "tripA");
+    const internals = client as unknown as {
+      subscribed: boolean;
+      snapshot: unknown;
+    };
+    internals.subscribed = true;
+    internals.snapshot = { title: "cached" };
+
+    expect(client.isSubscribed).toBe(true);
+    expect(client.currentSnapshot).toEqual({ title: "cached" });
+
+    client.discardSnapshot();
+
+    expect(client.isSubscribed).toBe(false);
+    expect(client.currentSnapshot).toBeUndefined();
+  });
+});

--- a/tests/unit/trip-cache.test.ts
+++ b/tests/unit/trip-cache.test.ts
@@ -7,10 +7,15 @@ import type { ShareDBPool } from "../../src/transport/sharedb.ts";
 class FakeShareDBClient extends EventEmitter {
   public version = 1;
   public subscribeCalled = 0;
+  public discardCalled = 0;
 
   async subscribe() {
     this.subscribeCalled++;
     return { title: "Test Trip", sections: [] };
+  }
+
+  discardSnapshot() {
+    this.discardCalled++;
   }
 }
 
@@ -54,6 +59,31 @@ describe("TripCache event listener leak", () => {
       cache.invalidate("tripA");
       expect(fakeClient.listenerCount("remoteOp")).toBe(0);
     }
+  });
+
+  it("discards the client snapshot on invalidate so the next get refetches", async () => {
+    const fakeClient = new FakeShareDBClient();
+    const fakeRest = {
+      getTripWithResources: async () => ({ geos: [] }),
+    } as unknown as RestClient;
+
+    const fakePool = {
+      get: () => fakeClient,
+    } as unknown as ShareDBPool;
+
+    const cache = new TripCache(fakeRest, fakePool);
+
+    await cache.get("tripA");
+    expect(fakeClient.subscribeCalled).toBe(1);
+
+    // A failed submit invalidates the entry. The client must be told to drop its
+    // frozen snapshot, otherwise the next subscribe() would serve stale data.
+    cache.invalidate("tripA");
+    expect(fakeClient.discardCalled).toBe(1);
+
+    // Next read must re-subscribe rather than reuse the dropped entry.
+    await cache.get("tripA");
+    expect(fakeClient.subscribeCalled).toBe(2);
   });
 
   it("unregisters listener on clear", async () => {


### PR DESCRIPTION
…after invalidate

Two bugs in the mutation retry / cache-sync path:

Retry idempotency: an op we authored echoes back from the server with src === our session id. handleOpFrame only recognized it as "ours" while a matching pending entry still existed. A late ack (arriving after the 10s submit timeout cleared the entry) or a duplicate ack from a rate-limit retry fell through and was re-emitted as a remoteOp, so the trip cache applied our mutation a second time and produced duplicate blocks. Gate on src instead: own ops resolve their pending submit if present, and are otherwise dropped without re-emitting or rewinding the version.

Cache-sync: ShareDBClient.snapshot is frozen at first subscribe (ops flow through the trip cache, not the client), and subscribe() short-circuits on `subscribed && snapshot`. After a failed submit invalidated the cache, the next get() re-subscribed and received that stale in-memory copy instead of refetching. TripCache now calls a new discardSnapshot() when it drops an entry, forcing the next subscribe() to re-request fresh server state.


Claude-Session: https://claude.ai/code/session_01V8mtbJgtgheJJe8nzGoEwU

## Summary

<!-- What changes, and why? 2-3 sentences in your own words.
     If an agent drafted this, edit it before requesting review. -->

## Test plan

<!-- How did you verify this? Commands run, edge cases, what you
     manually checked beyond CI. "CI is green" is not a test plan. -->

## Agent-facing surface changes

<!-- Tick only if applicable; delete the section otherwise. -->

- [ ] Changed a tool description, parameter doc, or error message
      (these are prompts shipped to other agents — review for
      injection risk and clarity)
- [ ] Changed or relaxed an invariant in `docs/architecture.md`
