### PR TITLE
fix(auth): retry failed startup probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The agent calls the tools, interleaves places and notes for each day, adds hotel
 ## What's New (Unreleased)
 
 - `wanderlog_search_hotels` — search Wanderlog's hotel aggregator across airbnb, expedia, google, and kayak. Returns ranked offers with per-vendor price comparison and faceted filter discovery so the LLM never has to memorise Wanderlog's internal enum values.
+- A failed startup authentication probe now gets one shared retry on the first tool call, allowing valid sessions to recover from a transient network or proxy error without restarting the server.
 
 ## What's New in v0.3.1
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -161,12 +161,40 @@ const AUTH_ERROR_RESPONSE = {
   isError: true,
 };
 
-function requireAuth(
+type ToolHandler = (
+  args: Record<string, unknown>,
+) => Promise<{
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+}>;
+
+const lazyAuthAttempts = new WeakMap<AppContext, Promise<boolean>>();
+
+async function ensureAuthenticated(ctx: AppContext): Promise<boolean> {
+  if (ctx.authenticated) return true;
+
+  let attempt = lazyAuthAttempts.get(ctx);
+  if (!attempt) {
+    attempt = ctx.rest
+      .getUser()
+      .then((user) => {
+        ctx.userId = user.id;
+        ctx.authenticated = true;
+        return true;
+      })
+      .catch(() => false);
+    lazyAuthAttempts.set(ctx, attempt);
+  }
+
+  return attempt;
+}
+
+export function requireAuth(
   ctx: AppContext,
-  handler: (args: Record<string, unknown>) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>,
+  handler: ToolHandler,
 ) {
   return async (args: Record<string, unknown>) => {
-    if (!ctx.authenticated) return AUTH_ERROR_RESPONSE;
+    if (!(await ensureAuthenticated(ctx))) return AUTH_ERROR_RESPONSE;
     return handler(args);
   };
 }

--- a/tests/unit/server-auth.test.ts
+++ b/tests/unit/server-auth.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import { requireAuth } from "../../src/server.ts";
+
+const successResponse = {
+  content: [{ type: "text" as const, text: "ok" }],
+};
+
+function createContext(getUser: ReturnType<typeof vi.fn>, authenticated = false): AppContext {
+  return {
+    authenticated,
+    rest: { getUser } as unknown as AppContext["rest"],
+  } as AppContext;
+}
+
+describe("requireAuth", () => {
+  it("does not probe again after startup authentication succeeds", async () => {
+    const getUser = vi.fn();
+    const handler = vi.fn().mockResolvedValue(successResponse);
+    const guarded = requireAuth(createContext(getUser, true), handler);
+
+    await expect(guarded({})).resolves.toEqual(successResponse);
+    expect(getUser).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("recovers a valid session after the startup probe failed", async () => {
+    const getUser = vi.fn().mockResolvedValue({ id: 42, username: "traveler" });
+    const ctx = createContext(getUser);
+    const handler = vi.fn().mockResolvedValue(successResponse);
+    const guarded = requireAuth(ctx, handler);
+
+    await expect(guarded({})).resolves.toEqual(successResponse);
+    expect(getUser).toHaveBeenCalledOnce();
+    expect(ctx.authenticated).toBe(true);
+    expect(ctx.userId).toBe(42);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the authentication error when the retry fails", async () => {
+    const getUser = vi.fn().mockRejectedValue(new Error("secret transport detail"));
+    const handler = vi.fn().mockResolvedValue(successResponse);
+    const guarded = requireAuth(createContext(getUser), handler);
+
+    const response = await guarded({});
+
+    expect(response).toMatchObject({
+      isError: true,
+      content: [{ text: expect.stringContaining("Authentication required") }],
+    });
+    expect(response.content[0]?.text).not.toContain("secret transport detail");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("shares one in-flight retry across concurrent tool calls", async () => {
+    let resolveUser: ((user: { id: number; username: string }) => void) | undefined;
+    const getUser = vi.fn(
+      () =>
+        new Promise<{ id: number; username: string }>((resolve) => {
+          resolveUser = resolve;
+        }),
+    );
+    const ctx = createContext(getUser);
+    const firstHandler = vi.fn().mockResolvedValue(successResponse);
+    const secondHandler = vi.fn().mockResolvedValue(successResponse);
+
+    const firstCall = requireAuth(ctx, firstHandler)({});
+    const secondCall = requireAuth(ctx, secondHandler)({});
+
+    expect(getUser).toHaveBeenCalledOnce();
+    resolveUser?.({ id: 7, username: "traveler" });
+    await expect(Promise.all([firstCall, secondCall])).resolves.toEqual([
+      successResponse,
+      successResponse,
+    ]);
+    expect(firstHandler).toHaveBeenCalledOnce();
+    expect(secondHandler).toHaveBeenCalledOnce();
+  });
+
+  it("caches a failed retry to prevent repeated invalid-cookie probes", async () => {
+    const getUser = vi.fn().mockRejectedValue(new Error("invalid cookie"));
+    const handler = vi.fn().mockResolvedValue(successResponse);
+    const guarded = requireAuth(createContext(getUser), handler);
+
+    await guarded({});
+    await guarded({});
+
+    expect(getUser).toHaveBeenCalledOnce();
+    expect(handler).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- retry a failed startup authentication probe once on the first tool call
- share the retry across concurrent calls and cache failure to avoid retry storms
- preserve the existing authentication error when credentials remain invalid
- add focused regression coverage and an unreleased change note

## Root cause

The startup probe leaves `ctx.authenticated` false after any failure. Every tool's authentication guard then returns immediately and never asks `RestClient.getUser()` again, so a transient proxy or network failure disables the server until restart.

Closes #4.

## Validation

- `npx vitest run tests/unit/server-auth.test.ts` — 5 passed
- `npm run test` — 393 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run lint` — passed with 35 pre-existing warnings and no errors
- `git diff --check` — passed

No live credentials or Wanderlog account data were used.
