### PR TITLE
getTrip: read via REST directly, skip ShareDB WS subscribe for reads

### DIFF
--- a/src/tools/get-trip.ts
+++ b/src/tools/get-trip.ts
@@ -47,7 +47,19 @@ export async function getTrip(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const trip = await ctx.tripCache.get(args.trip_key);
+    // Fast path: read via REST directly, skipping the ShareDB WebSocket subscribe.
+    // The WebSocket is only needed for mutations (submitOp), not for reads.
+    // This avoids the ~5s WS handshake + subscribe overhead per call.
+    //
+    // For day-filtered queries we also go through REST so the user never waits
+    // on a WebSocket just to peek at a single day.
+    const trip = await ctx.rest.getTrip(args.trip_key);
+
+    // Warm the WebSocket cache in the background for any follow-up mutation calls.
+    // This is fire-and-forget: if the WS subscribe fails (e.g. stale cookie),
+    // it won't affect the read response we're about to return.
+    ctx.tripCache.get(args.trip_key).catch(() => {});
+
     const daySection = args.day ? resolveDay(trip, args.day) : undefined;
     const text = formatTrip(trip, args.response_format ?? "concise", daySection);
     return { content: [{ type: "text", text }] };


### PR DESCRIPTION
## Problem

`getTrip` was going through `tripCache.get()` which performs a **double fetch**:
1. REST GET `/api/tripPlans/{key}?clientSchemaVersion=2&registerView=true` — full TripPlan JSON
2. ShareDB WebSocket subscribe to `wsOverall/{key}?clientSchemaVersion=2` — full snapshot again via WS handshake

For a read-only tool, the WebSocket adds 3-10s of overhead (handshake + subscribe) on top of the already-complete REST response. For large trips (29+ days, 47+ places) this compounded into Hermes' 300s MCP timeout, making the tool unusable without the `day` filter workaround.

## Fix

`getTrip()` now calls `ctx.rest.getTrip(tripKey)` directly — a single REST call that returns instantly. The WebSocket subscribe is fired in the background (`ctx.tripCache.get().catch(() => {})`) to warm the cache for any follow-up mutation calls.

This means:
- **Reads are instant** — no WebSocket overhead for getTrip
- **Mutations still work** — the cache is pre-warmed in the background
- **No API change** — same schema, same response format
- **`day` filter still works** — but is no longer required for performance

## Testing
- Build passes (`npm run build`)
- All 388 unit tests pass (`npm run test`)
- Verified live against wanderlog.com with a 29-day, 47-place trip — response in <1s

## Impact
Minimal change (14 lines), no new dependencies, no architectural changes. The background cache warmup gracefully degrades if the WebSocket fails (stale cookie, network issue).