### PR TITLE
feat: add wanderlog_add_transit (ferry/bus/train) and wanderlog_add_car_rental tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Instead of clicking through the Wanderlog UI to plan a trip, you just ask:
 
 > *"Create a 14-day Japan Golden Route trip — Tokyo, Hakone, Kyoto, Nara, and Osaka."*
 
-The agent calls the tools, interleaves places and notes for each day, adds hotel blocks and checklists, and you end up with a fully populated Wanderlog trip in a few minutes.
+The agent calls the tools, interleaves places and notes for each day, adds hotel blocks, ferries, buses, trains, rental cars, and checklists, and you end up with a fully populated Wanderlog trip in a few minutes.
 
 **See a real example:** [14-day Japan Golden Route](https://wanderlog.com/view/dmvegdhqsa/japan-golden-route--tokyo--hakone--kyoto--nara--osaka) — built entirely by an AI agent using this MCP server.
 
@@ -98,6 +98,8 @@ and a ryokan in Shinjuku."
 | `wanderlog_edit_note` | Find-and-replace text in notes, place annotations, and checklists |
 | `wanderlog_remove_note` | Remove a standalone note block by natural-language reference |
 | `wanderlog_add_hotel` | Add a hotel booking with check-in/check-out dates |
+| `wanderlog_add_transit` | Add a ferry, bus, or train leg (carrier, from/to, dates/times) to the shared Transit section |
+| `wanderlog_add_car_rental` | Add a rental car with pick-up/drop-off locations and times |
 | `wanderlog_add_checklist` | Add a pre-trip or per-day checklist |
 | `wanderlog_add_expense` | Log a budget expense (amount, category, currency), optionally linked to a place |
 | `wanderlog_list_expenses` | List budget expenses, optionally filtered by description / date / amount / currency |

--- a/src/formatters/trip-summary.ts
+++ b/src/formatters/trip-summary.ts
@@ -6,8 +6,9 @@ import type {
   NoteBlock,
   PlaceBlock,
   QuillDelta,
+  RentalCarBlock,
   Section,
-  TrainBlock,
+  TransitBlock,
   TripPlan,
   TripPlanSummary,
   UnknownBlock,
@@ -107,6 +108,8 @@ function sectionIcon(section: Section): string {
       return "✈";
     case "transit":
       return "🚆";
+    case "rentalCars":
+      return "🚗";
     case "textOnly":
       return "📝";
     default:
@@ -122,6 +125,8 @@ function sectionDefaultHeading(section: Section): string {
       return "Flights";
     case "transit":
       return "Transit";
+    case "rentalCars":
+      return "Rental cars";
     default:
       return "Places";
   }
@@ -176,7 +181,11 @@ export function formatBlockLine(block: Block, format: ResponseFormat): string | 
       case "flight":
         return formatFlightBlock(block as FlightBlock, format);
       case "train":
-        return formatTrainBlock(block as TrainBlock, format);
+      case "ferry":
+      case "bus":
+        return formatTransitBlock(block as TransitBlock, format);
+      case "rentalCar":
+        return formatRentalCarBlock(block as RentalCarBlock, format);
       default:
         return formatUnknownBlock(block as UnknownBlock);
     }
@@ -286,22 +295,46 @@ function formatFlightBlock(block: FlightBlock, format: ResponseFormat): string {
   return parts.join(" · ");
 }
 
-function formatTrainBlock(block: TrainBlock, format: ResponseFormat): string {
-  const carrier = block.carrier ?? "Train";
+const TRANSIT_ICON: Record<string, string> = { train: "🚆", ferry: "⛴", bus: "🚌" };
+
+function formatTransitBlock(block: TransitBlock, format: ResponseFormat): string {
+  const icon = TRANSIT_ICON[block.type] ?? "🚆";
+  const carrier = block.carrier ?? block.type;
   const from = block.depart?.place?.name ?? "?";
   const to = block.arrive?.place?.name ?? "?";
   const departDate = block.depart?.date ?? "";
   const departTime = block.depart?.time ? ` ${block.depart.time}` : "";
 
   if (format === "concise") {
-    return `🚆 ${carrier} · ${from} → ${to}${departDate ? ` · ${departDate}${departTime}` : ""}`;
+    return `${icon} ${carrier} · ${from} → ${to}${departDate ? ` · ${departDate}${departTime}` : ""}`;
   }
   const parts = [
-    `🚆 ${carrier}`,
+    `${icon} ${carrier}`,
     `${from} → ${to}`,
     `${departDate}${departTime} → ${block.arrive?.date ?? ""}${block.arrive?.time ? ` ${block.arrive.time}` : ""}`,
   ];
   if (block.confirmationNumber) parts.push(`conf. ${block.confirmationNumber}`);
+  if (block.travelerNames?.length) parts.push(`pax: ${block.travelerNames.join(", ")}`);
+  return parts.join(" · ");
+}
+
+function formatRentalCarBlock(block: RentalCarBlock, format: ResponseFormat): string {
+  const pickPlace = block.pickUp?.place?.name ?? "?";
+  const dropPlace = block.dropOff?.place?.name ?? "?";
+  const pick =
+    `${block.pickUp?.date ?? ""}${block.pickUp?.time ? ` ${block.pickUp.time}` : ""}`.trim();
+  const drop =
+    `${block.dropOff?.date ?? ""}${block.dropOff?.time ? ` ${block.dropOff.time}` : ""}`.trim();
+
+  if (format === "concise") {
+    return `🚗 ${pickPlace} → ${dropPlace}${pick ? ` · ${pick} → ${drop}` : ""}`;
+  }
+  const parts = [
+    `🚗 pick-up ${pickPlace}${pick ? ` ${pick}` : ""}`,
+    `drop-off ${dropPlace}${drop ? ` ${drop}` : ""}`,
+  ];
+  if (block.confirmationNumber) parts.push(`conf. ${block.confirmationNumber}`);
+  if (block.travelerNames?.length) parts.push(`pax: ${block.travelerNames.join(", ")}`);
   return parts.join(" · ");
 }
 

--- a/src/resolvers/place-ref.ts
+++ b/src/resolvers/place-ref.ts
@@ -19,6 +19,15 @@ const MAX_AMBIGUOUS_CANDIDATES = 10;
 const HOTEL_KEYWORDS = new Set(["the hotel", "hotel", "my hotel"]);
 const FLIGHT_KEYWORDS = new Set(["the flight", "flight", "my flight"]);
 const TRAIN_KEYWORDS = new Set(["the train", "train", "my train"]);
+const FERRY_KEYWORDS = new Set(["the ferry", "ferry", "my ferry"]);
+const BUS_KEYWORDS = new Set(["the bus", "bus", "my bus"]);
+const RENTAL_CAR_KEYWORDS = new Set([
+  "the rental car",
+  "rental car",
+  "the car",
+  "my rental car",
+  "my car",
+]);
 
 const WORD_ORDINALS: Record<string, number> = {
   first: 1,
@@ -77,8 +86,9 @@ export function parseOrdinal(ref: string): ParsedOrdinal | null {
  *   1. Compound "<thing> on <context>" — left side resolved by stages 2-4,
  *      then filtered to candidates whose parent section matches the context
  *      (currently only day references are understood on the right).
- *   2. Role keywords ("the hotel", "the flight", "the train") — first block
- *      in the appropriate role section.
+ *   2. Role keywords ("the hotel", "the flight", "the train", "the ferry",
+ *      "the bus", "the rental car") — first block in the appropriate role
+ *      section.
  *   3. Exact (case-insensitive) match against `block.place.name`.
  *   4. Substring (case-insensitive) match against `block.place.name`.
  *
@@ -144,6 +154,23 @@ function matchRoleKeyword(trip: TripPlan, ref: string): PlaceRefMatch[] {
       (s) => s.type === "transit",
       (b) => b.type === "train",
     );
+  }
+  if (FERRY_KEYWORDS.has(ref)) {
+    return firstBlockOfSectionType(
+      trip,
+      (s) => s.type === "transit",
+      (b) => b.type === "ferry",
+    );
+  }
+  if (BUS_KEYWORDS.has(ref)) {
+    return firstBlockOfSectionType(
+      trip,
+      (s) => s.type === "transit",
+      (b) => b.type === "bus",
+    );
+  }
+  if (RENTAL_CAR_KEYWORDS.has(ref)) {
+    return firstBlockOfSectionType(trip, (s) => s.type === "rentalCars");
   }
   return [];
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -150,6 +150,12 @@ import {
   deleteSectionDescription,
   deleteSectionInputSchema,
 } from "./tools/delete-section.js";
+import { addTransit, addTransitDescription, addTransitInputSchema } from "./tools/add-transit.js";
+import {
+  addCarRental,
+  addCarRentalDescription,
+  addCarRentalInputSchema,
+} from "./tools/add-car-rental.js";
 
 const AUTH_ERROR_RESPONSE = {
   content: [
@@ -200,6 +206,8 @@ of places. A complete itinerary uses these building blocks:
      to list curated user-written guides for the destination, then get_guide with the chosen
      guide_key to read the full content. Use this for OTHER people's published guides; for
      your own trips use wanderlog_get_trip.
+  8. wanderlog_add_transit — ferry / bus / train legs between places (carrier, from/to, dates,
+     times). wanderlog_add_car_rental — a rental car with pick-up and drop-off locations/times.
 
 Example add_place call with all features:
   wanderlog_add_place(trip_key, place: "Sensō-ji", day: "day 1",
@@ -547,6 +555,26 @@ export function buildServer(ctx: AppContext): McpServer {
     },
     requireAuth(ctx, async (args) =>
       deleteSection(ctx, args as Parameters<typeof deleteSection>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_add_transit",
+    {
+      title: "Add a ferry, bus, or train leg",
+      description: addTransitDescription,
+      inputSchema: addTransitInputSchema,
+    },
+    requireAuth(ctx, async (args) => addTransit(ctx, args as Parameters<typeof addTransit>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_add_car_rental",
+    {
+      title: "Add a rental car",
+      description: addCarRentalDescription,
+      inputSchema: addCarRentalInputSchema,
+    },
+    requireAuth(ctx, async (args) => addCarRental(ctx, args as Parameters<typeof addCarRental>[1])),
   );
 
   return server;

--- a/src/tools/add-car-rental.ts
+++ b/src/tools/add-car-rental.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError } from "../errors.js";
+import type { RentalCarEndpoint } from "../types.js";
+import {
+  buildRentalCarBlock,
+  requireUserId,
+  resolveEndpointPlace,
+  sectionInsertOp,
+  submitOp,
+  validateChronology,
+} from "./shared.js";
+
+export const addCarRentalInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to add the rental car to."),
+  pickup_location: z
+    .string()
+    .min(1)
+    .describe("Pick-up location — agency branch or airport, e.g. 'Europcar Cancun Airport'."),
+  pickup_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .describe("Pick-up date."),
+  pickup_time: z
+    .string()
+    .regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, "must be HH:mm (00:00–23:59)")
+    .describe("Pick-up time (24h)."),
+  dropoff_location: z.string().min(1).describe("Drop-off location."),
+  dropoff_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .describe("Drop-off date."),
+  dropoff_time: z
+    .string()
+    .regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, "must be HH:mm (00:00–23:59)")
+    .describe("Drop-off time (24h)."),
+  confirmation_number: z.string().optional().describe("Booking/confirmation number (optional)."),
+  notes: z.string().optional().describe("Free-text notes shown on the block (optional)."),
+};
+
+export const addCarRentalDescription = `
+Adds a rental car to a Wanderlog trip, covering a pick-up and drop-off window. Locations are
+matched against Google Places near the trip. The rental firm is whatever you pick as the
+location — there is no separate company field. A "Rental cars" section is created if absent.
+
+Returns confirmation with the resolved pick-up and drop-off.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  pickup_location: string;
+  pickup_date: string;
+  pickup_time: string;
+  dropoff_location: string;
+  dropoff_date: string;
+  dropoff_time: string;
+  confirmation_number?: string;
+  notes?: string;
+};
+
+export async function addCarRental(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    validateChronology(
+      "pickup",
+      args.pickup_date,
+      args.pickup_time,
+      "dropoff",
+      args.dropoff_date,
+      args.dropoff_time,
+    );
+
+    const userId = requireUserId(ctx);
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    const [pickPlace, dropPlace] = await Promise.all([
+      resolveEndpointPlace(ctx, trip, entry.geos, args.pickup_location),
+      resolveEndpointPlace(ctx, trip, entry.geos, args.dropoff_location),
+    ]);
+
+    const pickUp: RentalCarEndpoint = {
+      date: args.pickup_date,
+      time: args.pickup_time,
+      place: pickPlace,
+    };
+    const dropOff: RentalCarEndpoint = {
+      date: args.dropoff_date,
+      time: args.dropoff_time,
+      place: dropPlace,
+    };
+
+    const block = buildRentalCarBlock(userId, {
+      pickUp,
+      dropOff,
+      confirmationNumber: args.confirmation_number,
+      notes: args.notes,
+    });
+
+    const op = sectionInsertOp(trip, "rentalCars", block);
+    await submitOp(ctx, args.trip_key, [op]);
+
+    const text = `Added rental car to "${trip.title}" · pick-up ${pickPlace.name} ${args.pickup_date} ${args.pickup_time} → drop-off ${dropPlace.name} ${args.dropoff_date} ${args.dropoff_time}.`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/add-expense.ts
+++ b/src/tools/add-expense.ts
@@ -47,7 +47,7 @@ export const addExpenseInputSchema = {
     .min(1)
     .optional()
     .describe(
-      "Optional natural-language reference to link this expense to a place in the trip (e.g. 'Sensō-ji', 'the hotel'). Omit to log an unlinked expense (counts toward the budget total but isn't attached to a place).",
+      "Optional natural-language reference to link this expense to something in the trip — a place ('Sensō-ji', 'the hotel'), or a transit/rental reservation ('the ferry', 'the bus', 'the train', 'the rental car'). Omit to log an unlinked expense (counts toward the budget total but isn't attached).",
     ),
   date: z
     .string()

--- a/src/tools/add-transit.ts
+++ b/src/tools/add-transit.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import { WanderlogError } from "../errors.js";
+import type { TransitEndpoint } from "../types.js";
+import {
+  buildTransitBlock,
+  requireUserId,
+  resolveEndpointPlace,
+  sectionInsertOp,
+  submitOp,
+  validateChronology,
+} from "./shared.js";
+
+export const addTransitInputSchema = {
+  trip_key: z.string().min(1).describe("The trip to add the transit leg to."),
+  type: z
+    .enum(["ferry", "bus", "train"])
+    .describe("Kind of transit reservation. Flights use their own flow; not here."),
+  carrier: z
+    .string()
+    .min(1)
+    .describe("Operator / line name, e.g. 'Brittany Ferries', 'FlixBus', 'SNCF'."),
+  from: z.string().min(1).describe("Departure place (terminal/station), resolved near the trip."),
+  to: z.string().min(1).describe("Arrival place (terminal/station)."),
+  depart_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .describe("Departure date."),
+  depart_time: z
+    .string()
+    .regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, "must be HH:mm (00:00–23:59)")
+    .describe("Departure time (24h)."),
+  arrive_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "must be YYYY-MM-DD")
+    .describe("Arrival date."),
+  arrive_time: z
+    .string()
+    .regex(/^(?:[01]\d|2[0-3]):[0-5]\d$/, "must be HH:mm (00:00–23:59)")
+    .describe("Arrival time (24h)."),
+  confirmation_number: z.string().optional().describe("Booking/confirmation number (optional)."),
+  notes: z.string().optional().describe("Free-text notes shown on the block (optional)."),
+};
+
+export const addTransitDescription = `
+Adds a ferry, bus, or train leg to a Wanderlog trip. Departure and arrival places are matched
+against Google Places near the trip's destination. Ferries, buses and trains share the trip's
+"Transit" section, which is created automatically if absent.
+
+Returns confirmation with the resolved route and departure time.
+`.trim();
+
+type Args = {
+  trip_key: string;
+  type: "ferry" | "bus" | "train";
+  carrier: string;
+  from: string;
+  to: string;
+  depart_date: string;
+  depart_time: string;
+  arrive_date: string;
+  arrive_time: string;
+  confirmation_number?: string;
+  notes?: string;
+};
+
+export async function addTransit(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    validateChronology(
+      "depart",
+      args.depart_date,
+      args.depart_time,
+      "arrive",
+      args.arrive_date,
+      args.arrive_time,
+    );
+
+    const userId = requireUserId(ctx);
+    const entry = await ctx.tripCache.getEntry(args.trip_key);
+    const trip = entry.snapshot;
+
+    const [fromPlace, toPlace] = await Promise.all([
+      resolveEndpointPlace(ctx, trip, entry.geos, args.from),
+      resolveEndpointPlace(ctx, trip, entry.geos, args.to),
+    ]);
+
+    const depart: TransitEndpoint = {
+      place: fromPlace,
+      date: args.depart_date,
+      time: args.depart_time,
+    };
+    const arrive: TransitEndpoint = {
+      place: toPlace,
+      date: args.arrive_date,
+      time: args.arrive_time,
+    };
+
+    const block = buildTransitBlock(args.type, userId, {
+      carrier: args.carrier,
+      depart,
+      arrive,
+      confirmationNumber: args.confirmation_number,
+      notes: args.notes,
+    });
+
+    const op = sectionInsertOp(trip, "transit", block);
+    await submitOp(ctx, args.trip_key, [op]);
+
+    const text = `Added ${args.type} ${args.carrier} to "${trip.title}" · ${fromPlace.name} → ${toPlace.name} · ${args.depart_date} ${args.depart_time}.`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -2,7 +2,16 @@ import type { AppContext } from "../context.js";
 import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import { resolveDay } from "../resolvers/day.js";
-import type { Block, ChecklistItem, Geo, PlaceData, Section, TripPlan } from "../types.js";
+import type {
+  Block,
+  ChecklistItem,
+  Geo,
+  PlaceData,
+  RentalCarEndpoint,
+  Section,
+  TransitEndpoint,
+  TripPlan,
+} from "../types.js";
 import { isPlaceBlock } from "../types.js";
 
 /**
@@ -303,6 +312,165 @@ export function buildNoteBlock(userId: number): Record<string, unknown> {
     addedBy: { type: "user", userId },
     attachments: [],
   };
+}
+
+export function buildTransitBlock(
+  type: "ferry" | "bus" | "train",
+  userId: number,
+  args: {
+    carrier: string;
+    depart: TransitEndpoint;
+    arrive: TransitEndpoint;
+    confirmationNumber?: string;
+    travelerNames?: string[];
+    notes?: string;
+  },
+): Block {
+  const block: Record<string, unknown> = {
+    id: generateBlockId(),
+    type,
+    carrier: args.carrier,
+    depart: args.depart,
+    arrive: args.arrive,
+    addedBy: { type: "user", userId },
+    text: { ops: [{ insert: args.notes ? `${args.notes}\n` : "\n" }] },
+    attachments: [],
+  };
+  if (args.confirmationNumber) block.confirmationNumber = args.confirmationNumber;
+  if (args.travelerNames && args.travelerNames.length > 0) {
+    block.travelerNames = args.travelerNames;
+  }
+  return block as unknown as Block;
+}
+
+export function buildRentalCarBlock(
+  userId: number,
+  args: {
+    pickUp: RentalCarEndpoint;
+    dropOff: RentalCarEndpoint;
+    confirmationNumber?: string;
+    travelerNames?: string[];
+    notes?: string;
+  },
+): Block {
+  const block: Record<string, unknown> = {
+    id: generateBlockId(),
+    type: "rentalCar",
+    addedBy: { type: "user", userId },
+    pickUp: args.pickUp,
+    dropOff: args.dropOff,
+    text: { ops: [{ insert: args.notes ? `${args.notes}\n` : "\n" }] },
+    attachments: [],
+  };
+  if (args.confirmationNumber) block.confirmationNumber = args.confirmationNumber;
+  if (args.travelerNames && args.travelerNames.length > 0) {
+    block.travelerNames = args.travelerNames;
+  }
+  return block as unknown as Block;
+}
+
+const TRANSIT_SECTION_META: Record<
+  "transit" | "rentalCars",
+  { heading: string; placeMarkerIcon: string; placeMarkerColor: string }
+> = {
+  transit: { heading: "Transit", placeMarkerIcon: "subway", placeMarkerColor: "#17b978" },
+  rentalCars: { heading: "Rental cars", placeMarkerIcon: "car", placeMarkerColor: "#38a4a6" },
+};
+
+/**
+ * Build a JSON0 `li` op that places `block` into the section of `sectionType`.
+ * Appends to an existing section's blocks, or inserts a new section (block
+ * embedded) at the end of itinerary.sections. Resolve-by-type keeps us safe
+ * against unstable indices (invariant #6).
+ */
+export function sectionInsertOp(
+  trip: TripPlan,
+  sectionType: "transit" | "rentalCars",
+  block: Block,
+): Json0Op {
+  const sections = trip.itinerary.sections;
+  const index = sections.findIndex((s) => s.type === sectionType);
+  if (index >= 0) {
+    return {
+      p: ["itinerary", "sections", index, "blocks", sections[index]!.blocks.length],
+      li: block,
+    };
+  }
+  const meta = TRANSIT_SECTION_META[sectionType];
+  const section = {
+    id: generateBlockId(),
+    type: sectionType,
+    mode: "placeList",
+    heading: meta.heading,
+    date: null,
+    blocks: [block],
+    placeMarkerColor: meta.placeMarkerColor,
+    placeMarkerIcon: meta.placeMarkerIcon,
+    text: { ops: [{ insert: "\n" }] },
+  };
+  return { p: ["itinerary", "sections", sections.length], li: section };
+}
+
+export function validateChronology(
+  startLabel: string,
+  startDate: string,
+  startTime: string,
+  endLabel: string,
+  endDate: string,
+  endTime: string,
+): void {
+  for (const [label, d] of [
+    [`${startLabel}_date`, startDate],
+    [`${endLabel}_date`, endDate],
+  ] as const) {
+    if (!isValidDate(d)) {
+      throw new WanderlogValidationError(`Invalid ${label}: "${d}". Use YYYY-MM-DD.`);
+    }
+  }
+  for (const [label, t] of [
+    [`${startLabel}_time`, startTime],
+    [`${endLabel}_time`, endTime],
+  ] as const) {
+    if (!TIME_REGEX.test(t)) {
+      throw new WanderlogValidationError(`Invalid ${label}: "${t}". Use HH:mm (00:00–23:59).`);
+    }
+  }
+  // Zero-padded ISO "YYYY-MM-DDTHH:mm" sorts chronologically as a string.
+  if (`${endDate}T${endTime}` < `${startDate}T${startTime}`) {
+    throw new WanderlogValidationError(
+      `${endLabel} (${endDate} ${endTime}) must be on or after ${startLabel} (${startDate} ${startTime}).`,
+    );
+  }
+}
+
+/** Resolve a place-name query to full PlaceData, biased to the trip center. */
+export async function resolveEndpointPlace(
+  ctx: AppContext,
+  trip: TripPlan,
+  geos: Geo[] | undefined,
+  query: string,
+): Promise<PlaceData> {
+  const center = findTripCenter(trip, geos);
+  if (!center) {
+    throw new WanderlogValidationError(
+      `Cannot resolve "${query}" in "${trip.title}" because no location anchor is available`,
+      "This trip has no associated geo and no existing places.",
+    );
+  }
+  const predictions = await ctx.rest.searchPlacesAutocomplete({
+    input: query,
+    sessionToken: crypto.randomUUID(),
+    location: { latitude: center.lat, longitude: center.lng },
+    radius: 15000,
+  });
+  if (predictions.length === 0) {
+    throw new WanderlogError(
+      `No place found matching "${query}" near ${trip.title}`,
+      "place_not_found",
+      "Try a more specific name or check the spelling.",
+    );
+  }
+  return ctx.rest.getPlaceDetails(predictions[0]!.place_id);
 }
 
 /** Build a checklist block with pre-populated items. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,20 +90,47 @@ export type FlightBlock = {
   travelerNames?: string[];
 };
 
-export type StationEndpoint = {
+/**
+ * Shared shape for ferry / bus / train legs. Endpoints normally carry a full
+ * PlaceData, but `place` is optional because email-imported or partial blocks
+ * may omit it — reads must tolerate its absence (invariant #1).
+ */
+export type TransitEndpoint = {
+  place?: PlaceData;
   date?: string;
   time?: string;
-  place?: { name?: string; formatted_address?: string };
 };
 
-export type TrainBlock = {
+export type TransitBlock = {
   id: number;
-  type: "train";
+  type: "ferry" | "bus" | "train";
   carrier?: string;
-  depart?: StationEndpoint;
-  arrive?: StationEndpoint;
+  depart?: TransitEndpoint;
+  arrive?: TransitEndpoint;
+  confirmationNumber?: string;
+  /** Present on email-imported blocks (esp. trains); not set by our tools. */
+  travelerNames?: string[];
+  addedBy?: { type: string; userId: number };
+  text?: QuillDelta;
+  attachments?: unknown[];
+};
+
+export type RentalCarEndpoint = {
+  date?: string;
+  time?: string;
+  place?: PlaceData;
+};
+
+export type RentalCarBlock = {
+  id: number;
+  type: "rentalCar";
+  pickUp?: RentalCarEndpoint;
+  dropOff?: RentalCarEndpoint;
   confirmationNumber?: string;
   travelerNames?: string[];
+  addedBy?: { type: string; userId: number };
+  text?: QuillDelta;
+  attachments?: unknown[];
 };
 
 /** Fallback for unknown block types we haven't mapped yet. */
@@ -117,7 +144,8 @@ export type Block =
   | NoteBlock
   | ChecklistBlock
   | FlightBlock
-  | TrainBlock
+  | TransitBlock
+  | RentalCarBlock
   | UnknownBlock;
 
 export function isPlaceBlock(block: Block): block is PlaceBlock {
@@ -128,12 +156,21 @@ export function isChecklistBlock(block: Block): block is ChecklistBlock {
   return block.type === "checklist" && "items" in block;
 }
 
+export function isTransitBlock(block: Block): block is TransitBlock {
+  return block.type === "ferry" || block.type === "bus" || block.type === "train";
+}
+
+export function isRentalCarBlock(block: Block): block is RentalCarBlock {
+  return block.type === "rentalCar";
+}
+
 export type SectionType =
   | "textOnly"
   | "normal"
   | "hotels"
   | "flights"
   | "transit"
+  | "rentalCars"
   | string;
 
 export type Section = {

--- a/tests/fixtures/mixed-blocks-trip.ts
+++ b/tests/fixtures/mixed-blocks-trip.ts
@@ -72,12 +72,12 @@ export const mixedBlocksTrip: TripPlan = {
             depart: {
               date: "2025-11-18",
               time: "10:00",
-              place: { name: "Shinjuku Station" },
+              place: { name: "Shinjuku Station", place_id: "ChIJ_fixture_shinjuku" },
             },
             arrive: {
               date: "2025-11-18",
               time: "11:30",
-              place: { name: "Odawara Station" },
+              place: { name: "Odawara Station", place_id: "ChIJ_fixture_odawara" },
             },
           },
         ],

--- a/tests/integration/mcp-smoke.test.ts
+++ b/tests/integration/mcp-smoke.test.ts
@@ -87,7 +87,7 @@ describe("MCP stdio server (smoke)", () => {
     expect(p.pid).toBeDefined();
   });
 
-  it("responds to tools/list with all 27 tools", async () => {
+  it("responds to tools/list with all 32 tools", async () => {
     const p = startServer();
     await waitForReady(p);
     await initialize(p);
@@ -100,14 +100,18 @@ describe("MCP stdio server (smoke)", () => {
     expect(resp.result).toBeDefined();
     const names = resp.result.tools.map((t: { name: string }) => t.name).sort();
     expect(names).toEqual([
+      "wanderlog_add_car_rental",
       "wanderlog_add_checklist",
       "wanderlog_add_expense",
       "wanderlog_add_hotel",
       "wanderlog_add_journal",
       "wanderlog_add_note",
       "wanderlog_add_place",
+      "wanderlog_add_section",
+      "wanderlog_add_transit",
       "wanderlog_annotate_place",
       "wanderlog_create_trip",
+      "wanderlog_delete_section",
       "wanderlog_edit_expense",
       "wanderlog_edit_journal",
       "wanderlog_edit_note",
@@ -126,6 +130,7 @@ describe("MCP stdio server (smoke)", () => {
       "wanderlog_search_guides",
       "wanderlog_search_hotels",
       "wanderlog_search_places",
+      "wanderlog_update_section",
       "wanderlog_update_trip_dates",
     ]);
   });

--- a/tests/integration/transit-mutations.test.ts
+++ b/tests/integration/transit-mutations.test.ts
@@ -1,0 +1,141 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createContext, type AppContext } from "../../src/context.ts";
+import { addCarRental } from "../../src/tools/add-car-rental.ts";
+import { addTransit } from "../../src/tools/add-transit.ts";
+import { createTrip } from "../../src/tools/create-trip.ts";
+
+/**
+ * End-to-end round trip for the transit and rental-car tools. Creates a
+ * throwaway trip, exercises add_transit (ferry + bus sharing one section)
+ * and add_car_rental, then deletes the trip. Runs against the live
+ * Wanderlog API.
+ *
+ * If this test leaves a stray trip behind (e.g. crash mid-run), it'll
+ * show up in wanderlog.com labeled "WANDERDOG_TEST_<timestamp>" — delete
+ * it manually.
+ */
+describe("Transit & rental-car tools (live round-trip)", () => {
+  let ctx: AppContext;
+  let tripKey: string | undefined;
+
+  beforeAll(async () => {
+    if (!process.env.WANDERLOG_COOKIE) {
+      throw new Error("WANDERLOG_COOKIE must be set");
+    }
+    ctx = createContext();
+    const user = await ctx.rest.getUser();
+    ctx.userId = user.id;
+
+    const result = await createTrip(ctx, {
+      destination: "Guadeloupe",
+      start_date: "2099-01-01",
+      end_date: "2099-01-10",
+      title: `WANDERDOG_TEST_${Date.now()}`,
+      privacy: "private",
+    });
+    if (result.isError) {
+      throw new Error(`create_trip failed: ${result.content[0]!.text}`);
+    }
+    const keyMatch = /Key: (\w+)/.exec(result.content[0]!.text);
+    expect(keyMatch).not.toBeNull();
+    tripKey = keyMatch![1]!;
+  }, 30_000);
+
+  afterAll(async () => {
+    ctx?.pool.closeAll();
+    if (tripKey) {
+      try {
+        await ctx.rest.deleteTrip(tripKey);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  it("adds a ferry and a bus into a shared transit section", async () => {
+    expect(tripKey).toBeDefined();
+    const ferry = await addTransit(ctx, {
+      trip_key: tripKey!,
+      type: "ferry",
+      carrier: "Test Ferry Line",
+      from: "Trois-Rivières",
+      to: "Terre-de-Haut",
+      depart_date: "2099-01-02",
+      depart_time: "09:00",
+      arrive_date: "2099-01-02",
+      arrive_time: "10:00",
+      confirmation_number: "FERRY-1",
+    });
+    if (ferry.isError) {
+      throw new Error(`add_transit(ferry) failed: ${ferry.content[0]!.text}`);
+    }
+
+    const bus = await addTransit(ctx, {
+      trip_key: tripKey!,
+      type: "bus",
+      carrier: "Test Bus Co",
+      from: "Saint-François",
+      to: "Sainte-Anne",
+      depart_date: "2099-01-03",
+      depart_time: "14:00",
+      arrive_date: "2099-01-03",
+      arrive_time: "14:45",
+    });
+    if (bus.isError) {
+      throw new Error(`add_transit(bus) failed: ${bus.content[0]!.text}`);
+    }
+
+    const trip = await ctx.tripCache.get(tripKey!);
+    const transitSections = trip.itinerary.sections.filter((s) => s.type === "transit");
+    expect(transitSections).toHaveLength(1);
+    const types = transitSections[0]!.blocks.map((b) => b.type).sort();
+    expect(types).toEqual(["bus", "ferry"]);
+  }, 30_000);
+
+  it("adds a rental car into a rentalCars section", async () => {
+    expect(tripKey).toBeDefined();
+    const car = await addCarRental(ctx, {
+      trip_key: tripKey!,
+      pickup_location: "Pointe-à-Pitre Airport",
+      pickup_date: "2099-01-01",
+      pickup_time: "10:00",
+      dropoff_location: "Pointe-à-Pitre Airport",
+      dropoff_date: "2099-01-10",
+      dropoff_time: "10:00",
+      confirmation_number: "CAR-1",
+    });
+    if (car.isError) {
+      throw new Error(`add_car_rental failed: ${car.content[0]!.text}`);
+    }
+
+    const trip = await ctx.tripCache.get(tripKey!);
+    const rental = trip.itinerary.sections.find((s) => s.type === "rentalCars");
+    expect(rental).toBeDefined();
+    expect(rental!.blocks.some((b) => b.type === "rentalCar")).toBe(true);
+  }, 30_000);
+
+  it("rejects an arrival before departure without mutating the trip", async () => {
+    expect(tripKey).toBeDefined();
+    const before = await ctx.tripCache.get(tripKey!);
+    const beforeCount =
+      before.itinerary.sections.find((s) => s.type === "transit")?.blocks.length ?? 0;
+
+    const bad = await addTransit(ctx, {
+      trip_key: tripKey!,
+      type: "train",
+      carrier: "X",
+      from: "Saint-François",
+      to: "Sainte-Anne",
+      depart_date: "2099-01-04",
+      depart_time: "12:00",
+      arrive_date: "2099-01-04",
+      arrive_time: "11:00",
+    });
+    expect(bad.isError).toBe(true);
+
+    const after = await ctx.tripCache.get(tripKey!);
+    const afterCount =
+      after.itinerary.sections.find((s) => s.type === "transit")?.blocks.length ?? 0;
+    expect(afterCount).toBe(beforeCount);
+  }, 20_000);
+});

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { formatTrip, formatTripList } from "../../src/formatters/trip-summary.ts";
-import type { TripPlanSummary } from "../../src/types.ts";
+import { formatBlockLine, formatTrip, formatTripList } from "../../src/formatters/trip-summary.ts";
+import type { Block, TripPlanSummary } from "../../src/types.ts";
 import { queenstownTrip } from "../fixtures/queenstown-trip.ts";
 import { resolveDay } from "../../src/resolvers/day.ts";
 
@@ -94,5 +94,50 @@ describe("formatTrip", () => {
     const day = resolveDay(queenstownTrip, "day 3");
     const out = formatTrip(queenstownTrip, "concise", day);
     expect(out).toContain("no plans");
+  });
+});
+
+const mkTransit = (type: string) =>
+  ({
+    id: 1,
+    type,
+    carrier: "Acme Line",
+    depart: { place: { name: "Port A", place_id: "a" }, date: "2026-11-08", time: "09:00" },
+    arrive: { place: { name: "Port B", place_id: "b" }, date: "2026-11-08", time: "10:00" },
+    confirmationNumber: "CN1",
+  }) as unknown as Block;
+
+describe("transit block formatting", () => {
+  it("renders ferry, bus, train with an icon and route", () => {
+    for (const [type, icon] of [
+      ["ferry", "⛴"],
+      ["bus", "🚌"],
+      ["train", "🚆"],
+    ] as const) {
+      const line = formatBlockLine(mkTransit(type), "concise")!;
+      expect(line).toContain(icon);
+      expect(line).toContain("Acme Line");
+      expect(line).toContain("Port A");
+      expect(line).toContain("Port B");
+    }
+  });
+
+  it("renders a rentalCar with pickup/dropoff", () => {
+    const rental = {
+      id: 2,
+      type: "rentalCar",
+      pickUp: { date: "2026-11-01", time: "10:00", place: { name: "Europcar CUN", place_id: "c" } },
+      dropOff: {
+        date: "2026-11-08",
+        time: "13:00",
+        place: { name: "Europcar PDC", place_id: "d" },
+      },
+      confirmationNumber: "R9",
+    } as unknown as Block;
+    const line = formatBlockLine(rental, "detailed")!;
+    expect(line).toContain("🚗");
+    expect(line).toContain("Europcar CUN");
+    expect(line).toContain("Europcar PDC");
+    expect(line).toContain("R9");
   });
 });

--- a/tests/unit/place-ref.test.ts
+++ b/tests/unit/place-ref.test.ts
@@ -175,3 +175,57 @@ describe("resolvePlaceRef", () => {
     }
   });
 });
+
+function transitTrip(): TripPlan {
+  return {
+    itinerary: {
+      sections: [
+        {
+          id: 1,
+          type: "normal",
+          mode: "placeList",
+          heading: "Places to visit",
+          date: null,
+          blocks: [],
+        },
+        {
+          id: 2,
+          type: "transit",
+          mode: "placeList",
+          heading: "Transit",
+          date: null,
+          blocks: [
+            { id: 10, type: "ferry", carrier: "CTM" },
+            { id: 11, type: "bus", carrier: "FlixBus" },
+          ],
+        },
+        {
+          id: 3,
+          type: "rentalCars",
+          mode: "placeList",
+          heading: "Rental cars",
+          date: null,
+          blocks: [{ id: 20, type: "rentalCar" }],
+        },
+      ],
+    },
+  } as unknown as TripPlan;
+}
+
+describe("resolvePlaceRef role keywords for transit/rental", () => {
+  it("resolves 'the ferry' and 'the bus' to the right transit block", () => {
+    const trip = transitTrip();
+    const ferry = resolvePlaceRef(trip, "the ferry");
+    expect(ferry.kind).toBe("unique");
+    expect(ferry.kind === "unique" && ferry.match.block.id).toBe(10);
+    const bus = resolvePlaceRef(trip, "the bus");
+    expect(bus.kind === "unique" && bus.match.block.id).toBe(11);
+  });
+  it("resolves 'the rental car' and 'the car' to the rentalCars block", () => {
+    const trip = transitTrip();
+    for (const ref of ["the rental car", "the car"]) {
+      const r = resolvePlaceRef(trip, ref);
+      expect(r.kind === "unique" && r.match.block.id).toBe(20);
+    }
+  });
+});

--- a/tests/unit/transit-shared.test.ts
+++ b/tests/unit/transit-shared.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTransitBlock,
+  buildRentalCarBlock,
+  sectionInsertOp,
+  validateChronology,
+} from "../../src/tools/shared.ts";
+import { applyOp } from "../../src/ot/apply.ts";
+import type { PlaceData, TripPlan } from "../../src/types.ts";
+import { WanderlogValidationError } from "../../src/errors.ts";
+
+const place = (name: string): PlaceData => ({ name, place_id: `pid_${name}` });
+const ep = (name: string) => ({ place: place(name), date: "2026-11-08", time: "09:00" });
+
+describe("buildTransitBlock", () => {
+  it("builds a ferry with the confirmed shape", () => {
+    const b = buildTransitBlock("ferry", 42, {
+      carrier: "CTM DEHER",
+      depart: ep("A"),
+      arrive: { ...ep("B"), time: "10:00" },
+      confirmationNumber: "X1",
+      notes: "deck 2",
+    }) as Record<string, unknown>;
+    expect(b.type).toBe("ferry");
+    expect(b.carrier).toBe("CTM DEHER");
+    expect(b.addedBy).toEqual({ type: "user", userId: 42 });
+    expect(b.attachments).toEqual([]);
+    expect(b.text).toEqual({ ops: [{ insert: "deck 2\n" }] });
+    expect(b.confirmationNumber).toBe("X1");
+    expect("travelerNames" in b).toBe(false);
+    expect(JSON.stringify(b).includes("airportOrGeo")).toBe(false);
+  });
+
+  it("omits confirmationNumber and uses bare newline when notes absent", () => {
+    const b = buildTransitBlock("bus", 1, {
+      carrier: "FlixBus",
+      depart: ep("A"),
+      arrive: ep("B"),
+    }) as Record<string, unknown>;
+    expect(b.text).toEqual({ ops: [{ insert: "\n" }] });
+    expect("confirmationNumber" in b).toBe(false);
+  });
+
+  it("includes travelerNames only when non-empty", () => {
+    const withNames = buildTransitBlock("train", 1, {
+      carrier: "SNCF",
+      depart: ep("A"),
+      arrive: ep("B"),
+      travelerNames: ["Jo"],
+    }) as Record<string, unknown>;
+    expect(withNames.travelerNames).toEqual(["Jo"]);
+    const without = buildTransitBlock("train", 1, {
+      carrier: "SNCF",
+      depart: ep("A"),
+      arrive: ep("B"),
+      travelerNames: [],
+    }) as Record<string, unknown>;
+    expect("travelerNames" in without).toBe(false);
+  });
+});
+
+describe("buildRentalCarBlock", () => {
+  it("builds a rentalCar with pickUp/dropOff and no carrier/airportOrGeo", () => {
+    const b = buildRentalCarBlock(7, {
+      pickUp: { date: "2026-11-01", time: "10:00", place: place("Europcar CUN") },
+      dropOff: { date: "2026-11-08", time: "13:00", place: place("Europcar PDC") },
+      confirmationNumber: "C9",
+    }) as Record<string, unknown>;
+    expect(b.type).toBe("rentalCar");
+    expect((b.pickUp as { place: PlaceData }).place.name).toBe("Europcar CUN");
+    expect(b.confirmationNumber).toBe("C9");
+    expect("carrier" in b).toBe(false);
+    expect(JSON.stringify(b).includes("airportOrGeo")).toBe(false);
+  });
+});
+
+describe("sectionInsertOp", () => {
+  const base = (): TripPlan =>
+    ({
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "placeList",
+            heading: "Places to visit",
+            date: null,
+            blocks: [],
+          },
+        ],
+      },
+    }) as unknown as TripPlan;
+
+  it("creates a transit section when none exists and the block round-trips", () => {
+    const trip = base();
+    const block = buildTransitBlock("ferry", 1, { carrier: "C", depart: ep("A"), arrive: ep("B") });
+    const op = sectionInsertOp(trip, "transit", block);
+    const next = applyOp(trip, [op]);
+    const sec = next.itinerary.sections.find((s) => s.type === "transit")!;
+    expect(sec.heading).toBe("Transit");
+    expect(sec.placeMarkerIcon).toBe("subway");
+    expect(sec.placeMarkerColor).toBe("#17b978");
+    expect(sec.blocks).toHaveLength(1);
+    expect(sec.blocks[0]!.type).toBe("ferry");
+  });
+
+  it("appends to an existing rentalCars section", () => {
+    const trip = base();
+    trip.itinerary.sections.push({
+      id: 9,
+      type: "rentalCars",
+      mode: "placeList",
+      heading: "Rental cars",
+      date: null,
+      blocks: [{ id: 100, type: "rentalCar" }],
+    } as never);
+    const block = buildRentalCarBlock(1, {
+      pickUp: { date: "2026-11-01", time: "10:00", place: place("X") },
+      dropOff: { date: "2026-11-02", time: "10:00", place: place("Y") },
+    });
+    const op = sectionInsertOp(trip, "rentalCars", block);
+    const next = applyOp(trip, [op]);
+    const sec = next.itinerary.sections.find((s) => s.type === "rentalCars")!;
+    expect(sec.blocks).toHaveLength(2);
+  });
+});
+
+describe("validateChronology", () => {
+  it("accepts an overnight leg (22:00 day1 -> 06:00 day2)", () => {
+    expect(() =>
+      validateChronology("depart", "2026-11-08", "22:00", "arrive", "2026-11-09", "06:00"),
+    ).not.toThrow();
+  });
+  it("rejects arrive before depart on the same day", () => {
+    expect(() =>
+      validateChronology("depart", "2026-11-08", "10:00", "arrive", "2026-11-08", "09:00"),
+    ).toThrow(WanderlogValidationError);
+  });
+  it("rejects malformed date and time", () => {
+    expect(() =>
+      validateChronology("depart", "2026-13-01", "10:00", "arrive", "2026-11-08", "11:00"),
+    ).toThrow(WanderlogValidationError);
+    expect(() =>
+      validateChronology("depart", "2026-11-08", "25:00", "arrive", "2026-11-08", "11:00"),
+    ).toThrow(WanderlogValidationError);
+  });
+});

--- a/tests/unit/types-guards.test.ts
+++ b/tests/unit/types-guards.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { isTransitBlock, isRentalCarBlock, type Block } from "../../src/types.ts";
+
+const ferry = { id: 1, type: "ferry", carrier: "CTM" } as unknown as Block;
+const bus = { id: 2, type: "bus", carrier: "FlixBus" } as unknown as Block;
+const train = { id: 3, type: "train", carrier: "SNCF" } as unknown as Block;
+const rental = { id: 4, type: "rentalCar" } as unknown as Block;
+const place = { id: 5, type: "place", place: { name: "X", place_id: "p" } } as unknown as Block;
+
+describe("isTransitBlock", () => {
+  it("matches ferry, bus, train and nothing else", () => {
+    expect(isTransitBlock(ferry)).toBe(true);
+    expect(isTransitBlock(bus)).toBe(true);
+    expect(isTransitBlock(train)).toBe(true);
+    expect(isTransitBlock(rental)).toBe(false);
+    expect(isTransitBlock(place)).toBe(false);
+  });
+});
+
+describe("isRentalCarBlock", () => {
+  it("matches only rentalCar", () => {
+    expect(isRentalCarBlock(rental)).toBe(true);
+    expect(isRentalCarBlock(ferry)).toBe(false);
+    expect(isRentalCarBlock(place)).toBe(false);
+  });
+});


### PR DESCRIPTION
Hi @shaikhspeare 👋

Thanks for this — I've been using it to plan my own trips and it's saved me a bunch of
time. Wanted to give a little back, so here are a couple of additions. Hope you're keen to
keep developing it.

## Summary

Two new tools:

- **`wanderlog_add_transit`** — ferry / bus / train (one tool, `type` enum; they share the
  same block shape and the `transit` section).
- **`wanderlog_add_car_rental`** — pick-up/drop-off, its own `rentalCars` section.

Plus formatter rendering for these blocks (they showed as "unsupported" before — this
resolves #32) and natural-language refs (`"the ferry"`, `"the rental car"`) in
`resolvePlaceRef`, wired into `add_expense` so costs can link to them. Block shapes were
reverse-engineered from live trips and confirmed with a write-test + a UI check
(`airportOrGeo` turned out optional, so it's omitted). The `mcp-smoke` list is bumped to
32 — that also picks up the three `*_section` tools it was missing.

## Test plan

- `npm run build`, `npm run lint`, `npm run test` — clean; 403 unit tests, incl. builders,
  section-insert, overnight-safe date/time validation, formatter, resolver keywords.
- Live round-trip (`transit-mutations.test.ts`, throwaway trip, deleted after): ferry+bus
  land in one `transit` section, rental car in `rentalCars`, bad chronology is rejected.

## Agent-facing surface changes

- [x] Changed a tool description / parameter doc (2 new tools + `add_expense`'s `place` doc)

---

Two small asks — separate from this PR (this one is just the two tools above):

- Any chance you could push the `docs/` folder? It's gitignored, so contributors don't get
  the architecture/protocol notes `CLAUDE.md` points to — I ended up reverse-engineering
  the block shapes. Publishing it would make outside PRs a lot easier.
- Not included here, just a heads-up: I merged the other open PRs into my fork and ran this
  feature on top — all green, no conflicts between them. So I'd love to see them land too
  (#52, #51, #48, #22, and the Dependabot ones #50/#46; left out only #45). They stay their
  own separate PRs — I just wanted to confirm they play well together with this.
