### PR TITLE
Uplift `add-note` function to allow notes to be added in the Non-Itinerary section

### DIFF
--- a/src/tools/add-note.ts
+++ b/src/tools/add-note.ts
@@ -1,34 +1,51 @@
 import { z } from "zod";
 import type { AppContext } from "../context.js";
-import { WanderlogError } from "../errors.js";
+import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
+import type { TripPlan } from "../types.js";
 import {
   buildNoteBlock,
+  findSectionByRef,
   findTargetSection,
   requireUserId,
   submitOp,
+  type TargetSection,
 } from "./shared.js";
 
-export const addNoteInputSchema = {
-  trip_key: z
-    .string()
-    .min(1)
-    .describe("The trip to add the note to. Use wanderlog_list_trips if you don't know the key."),
-  text: z
-    .string()
-    .min(1)
-    .describe("The note text. Plain text — can be multi-line."),
-  day: z
-    .string()
-    .optional()
-    .describe(
-      "Optional day to add the note to. Accepts 'day 2', 'May 4', or ISO '2026-05-04'. Omit to add to the 'Places to visit' list.",
-    ),
-};
+export const addNoteInputSchema = z
+  .object({
+    trip_key: z
+      .string()
+      .min(1)
+      .describe(
+        "The trip to add the note to. Use wanderlog_list_trips if you don't know the key.",
+      ),
+    text: z
+      .string()
+      .min(1)
+      .describe("The note text. Plain text — can be multi-line."),
+    day: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Optional day to add the note to. Accepts 'day 2', 'May 4', or ISO '2026-05-04'. If 'section' is also provided, the section takes precedence. Omit both to add to the 'Places to visit' list.",
+      ),
+    section: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Optional undated section to add the note to, identified by its heading (e.g. 'Notes', 'Food & Drink', or 'Places to visit'). Matching is case-insensitive and takes precedence over 'day'. Omit both to add to the 'Places to visit' list.",
+      ),
+  });
 
 export const addNoteDescription = `
 Adds a text note to a Wanderlog trip. Notes appear inline between places in a day, acting as
 the connective tissue of the itinerary. Every well-built day should have notes between stops.
+Supply "day" for a dated itinerary day or "section" for an undated section such as "Notes"
+or "Food & Drink". When both are provided, "section" takes precedence. Omit both to add to
+the default "Places to visit" list.
 
 When to add a note (do this after adding each place or group of places):
 - How to get there: "Walk 15 min along the South Bank, or take the Jubilee line one stop"
@@ -40,11 +57,35 @@ When to add a note (do this after adding each place or group of places):
 Returns a confirmation of where the note was added.
 `.trim();
 
-type Args = {
-  trip_key: string;
-  text: string;
-  day?: string;
-};
+type Args = z.infer<typeof addNoteInputSchema>;
+
+function evaluateTargetSection(
+  trip: TripPlan,
+  { day, section }: Pick<Args, "day" | "section">,
+): TargetSection {
+  if (section !== undefined) {
+    const found = findSectionByRef(trip, section);
+    if (!found) {
+      throw new WanderlogValidationError(
+        `Section "${section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+      );
+    }
+    if (found.section.mode === "dayPlan" || found.section.date !== null) {
+      throw new WanderlogValidationError(
+        `Section "${found.section.heading || section}" is a dated section. Use the "day" parameter to add a note to an itinerary day.`,
+      );
+    }
+    return {
+      index: found.index,
+      section: found.section,
+      label: `section "${found.section.heading || section}"`,
+    };
+  }
+
+  if (day !== undefined) return findTargetSection(trip, day);
+
+  return findTargetSection(trip);
+}
 
 export async function addNote(
   ctx: AppContext,
@@ -55,7 +96,7 @@ export async function addNote(
     const entry = await ctx.tripCache.getEntry(args.trip_key);
     const trip = entry.snapshot;
 
-    const target = findTargetSection(trip, args.day);
+    const target = evaluateTargetSection(trip, args);
 
     // Step 1: Insert the note block with placeholder text
     const block = buildNoteBlock(userId);

--- a/src/tools/add-note.ts
+++ b/src/tools/add-note.ts
@@ -70,7 +70,7 @@ function evaluateTargetSection(
         `Section "${section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
       );
     }
-    if (found.section.mode === "dayPlan" || found.section.date !== null) {
+    if (found.section.mode === "dayPlan") {
       throw new WanderlogValidationError(
         `Section "${found.section.heading || section}" is a dated section. Use the "day" parameter to add a note to an itinerary day.`,
       );

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -280,10 +280,16 @@ export function findTripCenter(
  * Resolves the target section for adding a block — either a specific day
  * or the "Places to visit" list. Shared by add-place, add-note, add-checklist.
  */
+export type TargetSection = {
+  index: number;
+  section: Section;
+  label: string;
+};
+
 export function findTargetSection(
   trip: TripPlan,
   day?: string,
-): { index: number; section: Section; label: string } {
+): TargetSection {
   if (day) {
     const daySection = resolveDay(trip, day);
     const found = findDaySectionByDate(trip, daySection.date!);

--- a/tests/unit/add-note.test.ts
+++ b/tests/unit/add-note.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import type { Json0Op } from "../../src/ot/apply.ts";
+import {
+  addNote,
+  addNoteInputSchema,
+} from "../../src/tools/add-note.ts";
+import type { TripPlan } from "../../src/types.ts";
+import { checklistTrip } from "../fixtures/checklist-trip.ts";
+
+function makeFakeContext(trip: TripPlan): {
+  ctx: AppContext;
+  submittedOps: Json0Op[][];
+} {
+  const submittedOps: Json0Op[][] = [];
+  const ctx = {
+    userId: 3656632,
+    pool: {
+      get: () => ({
+        isSubscribed: true,
+        version: 1,
+        async submit(ops: Json0Op[]) {
+          submittedOps.push(ops);
+        },
+      }),
+    },
+    tripCache: {
+      getEntry: async () => ({ snapshot: structuredClone(trip) }),
+      applyLocalOp: () => {},
+      invalidate: () => {},
+    },
+  } as unknown as AppContext;
+  return { ctx, submittedOps };
+}
+
+describe("addNoteInputSchema", () => {
+  const base = { trip_key: "T", text: "Remember the tickets" };
+
+  it("accepts zero, one, or both targets", () => {
+    expect(addNoteInputSchema.safeParse(base).success).toBe(true);
+    expect(addNoteInputSchema.safeParse({ ...base, day: "day 1" }).success).toBe(true);
+    expect(addNoteInputSchema.safeParse({ ...base, section: "Notes" }).success).toBe(true);
+    expect(
+      addNoteInputSchema.safeParse({ ...base, day: "day 1", section: "Notes" }).success,
+    ).toBe(true);
+  });
+
+  it("rejects empty target strings", () => {
+    expect(addNoteInputSchema.safeParse({ ...base, day: "" }).success).toBe(false);
+    expect(addNoteInputSchema.safeParse({ ...base, section: "" }).success).toBe(false);
+  });
+});
+
+describe("addNote section targeting", () => {
+  it("defaults to Places to visit when no target is provided", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "No target",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("places to visit");
+    expect(submittedOps[0]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      1,
+      "blocks",
+      1,
+    ]);
+  });
+
+  it("lets section override day when both targets are provided", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "Two targets",
+      day: "day 1",
+      section: "Notes",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('section "Notes"');
+    expect(submittedOps[0]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      0,
+      "blocks",
+      0,
+    ]);
+  });
+
+  it("adds a note to a named undated section case-insensitively", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "Keep passport copies here",
+      section: "notes",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('section "Notes"');
+    expect(submittedOps).toHaveLength(2);
+    expect(submittedOps[0]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      0,
+      "blocks",
+      0,
+    ]);
+    expect((submittedOps[0]![0] as { li: { type: string } }).li.type).toBe("note");
+    expect(submittedOps[1]![0]).toMatchObject({
+      p: ["itinerary", "sections", 0, "blocks", 0, "text"],
+      t: "rich-text",
+      o: [{ insert: "Keep passport copies here\n" }],
+    });
+  });
+
+  it("adds a note to Places to visit when explicitly targeted", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "General trip reminder",
+      section: "Places to visit",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('section "Places to visit"');
+    expect(submittedOps[0]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      1,
+      "blocks",
+      1,
+    ]);
+  });
+
+  it("rejects an unknown section without submitting operations", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "Unknown destination",
+      section: "Does not exist",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain('Section "Does not exist" not found');
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("rejects a dated section heading without submitting operations", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "Use the day target instead",
+      section: "Arrival day",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("is a dated section");
+    expect(result.content[0]!.text).toContain('"day" parameter');
+    expect(submittedOps).toHaveLength(0);
+  });
+
+  it("preserves day targeting", async () => {
+    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "Day-level reminder",
+      day: "day 1",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("day 2026-06-01");
+    expect(submittedOps[0]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      2,
+      "blocks",
+      3,
+    ]);
+  });
+});

--- a/tests/unit/add-note.test.ts
+++ b/tests/unit/add-note.test.ts
@@ -148,8 +148,31 @@ describe("addNote section targeting", () => {
     expect(submittedOps).toHaveLength(0);
   });
 
-  it("rejects a dated section heading without submitting operations", async () => {
-    const { ctx, submittedOps } = makeFakeContext(checklistTrip);
+  it("allows a non-dayPlan section even when it has a date", async () => {
+    const trip = structuredClone(checklistTrip);
+    trip.itinerary.sections[0]!.date = "2026-06-01";
+    const { ctx, submittedOps } = makeFakeContext(trip);
+    const result = await addNote(ctx, {
+      trip_key: "T",
+      text: "Keep this in Notes",
+      section: "Notes",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain('section "Notes"');
+    expect(submittedOps[0]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      0,
+      "blocks",
+      0,
+    ]);
+  });
+
+  it("rejects a dayPlan section even when it has no date", async () => {
+    const trip = structuredClone(checklistTrip);
+    trip.itinerary.sections[2]!.date = null;
+    const { ctx, submittedOps } = makeFakeContext(trip);
     const result = await addNote(ctx, {
       trip_key: "T",
       text: "Use the day target instead",


### PR DESCRIPTION
## Summary

Currently `add-notes` does not allow you to add notes to a specific section in the Non-Itinerary section.

It does not just add notes to the "Places to visit" section anymore and allows you to specify the name of the section

## Test plan

- Asked Codex to add a note (screenshot to be provided) 
<img width="881" height="260" alt="Screenshot 2026-08-15 at 12 11 24 am" src="https://github.com/user-attachments/assets/5ae85613-6da5-4387-9c2a-d7b98f2818ed" />
<img width="535" height="368" alt="Screenshot 2026-08-15 at 12 11 37 am" src="https://github.com/user-attachments/assets/532ce7cb-d1ae-4f5b-8fe7-c2bcb9b321bb" />

## Agent-facing surface changes
- [x] Changed a tool description, parameter doc, or error message
      (these are prompts shipped to other agents — review for
      injection risk and clarity)
- [ ] Changed or relaxed an invariant in `docs/architecture.md`
