### PR TITLE
Fix stale paths in concurrent trip mutations

### DIFF
--- a/src/cache/trip-cache.ts
+++ b/src/cache/trip-cache.ts
@@ -3,7 +3,7 @@ import type { RestClient } from "../transport/rest.js";
 import type { ShareDBPool } from "../transport/sharedb.js";
 import type { Geo, TripPlan } from "../types.js";
 
-type CacheEntry = {
+export type CacheEntry = {
   snapshot: TripPlan;
   version: number;
   geos: Geo[];

--- a/src/tools/add-car-rental.ts
+++ b/src/tools/add-car-rental.ts
@@ -74,11 +74,9 @@ export async function addCarRental(
 
     const userId = requireUserId(ctx);
     const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
     const [pickPlace, dropPlace] = await Promise.all([
-      resolveEndpointPlace(ctx, trip, entry.geos, args.pickup_location),
-      resolveEndpointPlace(ctx, trip, entry.geos, args.dropoff_location),
+      resolveEndpointPlace(ctx, entry.snapshot, entry.geos, args.pickup_location),
+      resolveEndpointPlace(ctx, entry.snapshot, entry.geos, args.dropoff_location),
     ]);
 
     const pickUp: RentalCarEndpoint = {
@@ -92,17 +90,18 @@ export async function addCarRental(
       place: dropPlace,
     };
 
-    const block = buildRentalCarBlock(userId, {
-      pickUp,
-      dropOff,
-      confirmationNumber: args.confirmation_number,
-      notes: args.notes,
+    const tripTitle = await submitOp(ctx, args.trip_key, async (lockedEntry, submit) => {
+      const block = buildRentalCarBlock(userId, {
+        pickUp,
+        dropOff,
+        confirmationNumber: args.confirmation_number,
+        notes: args.notes,
+      });
+      await submit([sectionInsertOp(lockedEntry.snapshot, "rentalCars", block)]);
+      return lockedEntry.snapshot.title;
     });
 
-    const op = sectionInsertOp(trip, "rentalCars", block);
-    await submitOp(ctx, args.trip_key, [op]);
-
-    const text = `Added rental car to "${trip.title}" · pick-up ${pickPlace.name} ${args.pickup_date} ${args.pickup_time} → drop-off ${dropPlace.name} ${args.dropoff_date} ${args.dropoff_time}.`;
+    const text = `Added rental car to "${tripTitle}" · pick-up ${pickPlace.name} ${args.pickup_date} ${args.pickup_time} → drop-off ${dropPlace.name} ${args.dropoff_date} ${args.dropoff_time}.`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/add-checklist.ts
+++ b/src/tools/add-checklist.ts
@@ -55,24 +55,28 @@ export async function addChecklist(
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
     const userId = requireUserId(ctx);
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    const target = findTargetSection(trip, args.day);
-
-    const block = buildChecklistBlock(args.items, args.title ?? "", userId);
-    const insertIndex = target.section.blocks.length;
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "sections", target.index, "blocks", insertIndex],
-        li: block,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const target = findTargetSection(trip, args.day);
+      const block = buildChecklistBlock(args.items, args.title ?? "", userId);
+      const ops: Json0Op[] = [
+        {
+          p: [
+            "itinerary",
+            "sections",
+            target.index,
+            "blocks",
+            target.section.blocks.length,
+          ],
+          li: block,
+        },
+      ];
+      await submit(ops);
+      return { targetLabel: target.label, tripTitle: trip.title };
+    });
 
     const titlePart = args.title ? `"${args.title}" ` : "";
-    const text = `Added checklist ${titlePart}(${args.items.length} items) to ${target.label} in "${trip.title}".`;
+    const text = `Added checklist ${titlePart}(${args.items.length} items) to ${result.targetLabel} in "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/add-expense.ts
+++ b/src/tools/add-expense.ts
@@ -82,78 +82,80 @@ export async function addExpense(
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
     const userId = requireUserId(ctx);
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    // Linking to a place is optional — Wanderlog accepts unlinked expenses
-    // (blockId: null), which appear in the budget total without a place.
-    let blockId: number | null = null;
-    let associatedDate: string | null = null;
-    if (args.place) {
-      const result = resolvePlaceRef(trip, args.place);
-      if (result.kind === "ambiguous") {
-        const lines = result.candidates.map((c, i) => {
-          const name = isPlaceBlock(c.block) ? c.block.place.name : `block #${c.block.id}`;
-          const loc = c.section.date ? `day ${c.section.date}` : c.section.heading || "unscheduled";
-          return `  ${i + 1}. ${name} (${loc})`;
-        });
-        const text = `Multiple places match "${args.place}":\n${lines.join("\n")}\n\nRetry with a more specific reference.`;
-        return { content: [{ type: "text", text }] };
-      }
-      if (result.kind === "none") {
-        throw new WanderlogError(
-          `No place matching "${args.place}" found in "${trip.title}"`,
-          "place_ref_not_found",
-          {
-            hint: "Add the place to the trip first with wanderlog_add_place, or omit 'place' to log an unlinked expense.",
-            followUps: [
-              `Call wanderlog_get_trip with trip_key "${args.trip_key}" to see existing places.`,
-            ],
-          },
-        );
-      }
-      blockId = result.match.block.id;
-      associatedDate = result.match.section.date;
-    }
-
     const expenseDate = args.date ?? new Date().toISOString().slice(0, 10);
-
-    // Build the expense object matching Wanderlog's schema
-    const expense: Record<string, unknown> = {
-      id: generateBlockId(),
-      amount: {
-        amount: args.amount,
-        currencyCode: args.currency.toUpperCase(),
-      },
-      category: args.category,
-      description: args.description,
-      date: expenseDate,
-      paidByUserId: userId,
-      paidByUser: { type: "registered", id: userId },
-      splitWith: { type: "individuals", users: [] },
-      blockId: blockId,
-      associatedDate: associatedDate ?? expenseDate,
-    };
-
-    // Find the current expenses array length to insert at the end
-    const budget = (trip.itinerary as Record<string, unknown>).budget as
-      | Record<string, unknown>
-      | undefined;
-    const expenses = (budget?.expenses as unknown[] | undefined) ?? [];
-    const insertIndex = expenses.length;
-
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "budget", "expenses", insertIndex],
-        li: expense,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      let blockId: number | null = null;
+      let associatedDate: string | null = null;
+      if (args.place) {
+        const resolved = resolvePlaceRef(trip, args.place);
+        if (resolved.kind === "ambiguous") {
+          const lines = resolved.candidates.map((c, i) => {
+            const name = isPlaceBlock(c.block) ? c.block.place.name : `block #${c.block.id}`;
+            const loc = c.section.date
+              ? `day ${c.section.date}`
+              : c.section.heading || "unscheduled";
+            return `  ${i + 1}. ${name} (${loc})`;
+          });
+          return {
+            response: {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `Multiple places match "${args.place}":\n${lines.join("\n")}\n\nRetry with a more specific reference.`,
+                },
+              ],
+            },
+          };
+        }
+        if (resolved.kind === "none") {
+          throw new WanderlogError(
+            `No place matching "${args.place}" found in "${trip.title}"`,
+            "place_ref_not_found",
+            {
+              hint: "Add the place to the trip first with wanderlog_add_place, or omit 'place' to log an unlinked expense.",
+              followUps: [
+                `Call wanderlog_get_trip with trip_key "${args.trip_key}" to see existing places.`,
+              ],
+            },
+          );
+        }
+        blockId = resolved.match.block.id;
+        associatedDate = resolved.match.section.date;
+      }
+      const expense: Record<string, unknown> = {
+        id: generateBlockId(),
+        amount: {
+          amount: args.amount,
+          currencyCode: args.currency.toUpperCase(),
+        },
+        category: args.category,
+        description: args.description,
+        date: expenseDate,
+        paidByUserId: userId,
+        paidByUser: { type: "registered", id: userId },
+        splitWith: { type: "individuals", users: [] },
+        blockId,
+        associatedDate: associatedDate ?? expenseDate,
+      };
+      const budget = (trip.itinerary as Record<string, unknown>).budget as
+        | Record<string, unknown>
+        | undefined;
+      const expenses = (budget?.expenses as unknown[] | undefined) ?? [];
+      const ops: Json0Op[] = [
+        {
+          p: ["itinerary", "budget", "expenses", expenses.length],
+          li: expense,
+        },
+      ];
+      await submit(ops);
+      return { tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
 
     const currencyLabel = args.currency.toUpperCase();
     const linkLabel = args.place ? ` (linked to ${args.place})` : "";
-    const text = `Added expense: ${currencyLabel} ${args.amount} for "${args.description}"${linkLabel} in "${trip.title}".`;
+    const text = `Added expense: ${currencyLabel} ${args.amount} for "${args.description}"${linkLabel} in "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/add-hotel.ts
+++ b/src/tools/add-hotel.ts
@@ -56,12 +56,10 @@ export async function addHotel(
 
     const userId = requireUserId(ctx);
     const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    const center = findTripCenter(trip, entry.geos);
+    const center = findTripCenter(entry.snapshot, entry.geos);
     if (!center) {
       throw new WanderlogValidationError(
-        `Cannot add hotel to "${trip.title}" because no location anchor is available`,
+        `Cannot add hotel to "${entry.snapshot.title}" because no location anchor is available`,
         "This trip has no associated geo and no existing places.",
       );
     }
@@ -74,7 +72,7 @@ export async function addHotel(
     });
     if (predictions.length === 0) {
       throw new WanderlogError(
-        `No hotel found matching "${args.hotel}" near ${trip.title}`,
+        `No hotel found matching "${args.hotel}" near ${entry.snapshot.title}`,
         "hotel_not_found",
         "Try a more specific name or check the spelling.",
       );
@@ -82,46 +80,47 @@ export async function addHotel(
     const detail: PlaceData = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
     const imageKeys = await ctx.rest.getPlacePhotos(detail);
 
-    const block = buildPlaceBlock(detail, userId, {
-      hotel: {
-        checkIn: args.check_in,
-        checkOut: args.check_out,
-        travelerNames: [],
-        confirmationNumber: null,
-      },
+    const tripTitle = await submitOp(ctx, args.trip_key, async (lockedEntry, submit) => {
+      const trip = lockedEntry.snapshot;
+      const block = buildPlaceBlock(detail, userId, {
+        hotel: {
+          checkIn: args.check_in,
+          checkOut: args.check_out,
+          travelerNames: [],
+          confirmationNumber: null,
+        },
+      });
+      const existing = findHotelsSection(trip);
+      const sectionIndex = existing ? existing.index : Math.min(1, trip.itinerary.sections.length);
+      const blockPath = existing
+        ? ["itinerary", "sections", sectionIndex, "blocks", existing.section.blocks.length]
+        : ["itinerary", "sections", sectionIndex, "blocks", 0];
+      const ops: Json0Op[] = existing
+        ? [{ p: blockPath, li: block }]
+        : [
+            {
+              p: ["itinerary", "sections", sectionIndex],
+              li: {
+                id: Math.floor(Math.random() * 1_000_000_000),
+                type: "hotels",
+                mode: "placeList",
+                heading: "Hotels and lodging",
+                date: null,
+                blocks: [block],
+                placeMarkerColor: "#7045af",
+                placeMarkerIcon: "bed",
+                text: { ops: [{ insert: "\n" }] },
+              },
+            },
+          ];
+      if (imageKeys.length > 0) {
+        ops.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
+      }
+      await submit(ops);
+      return trip.title;
     });
 
-    const existing = findHotelsSection(trip);
-    const blockPath = existing
-      ? ["itinerary", "sections", existing.index, "blocks", existing.section.blocks.length]
-      : ["itinerary", "sections", 1, "blocks", 0];
-    const ops: Json0Op[] = existing
-      ? [{ p: blockPath, li: block }]
-      : [
-          {
-            // Insert a new hotels section after the Notes section (index 1).
-            // The existing sections shift down by 1.
-            p: ["itinerary", "sections", 1],
-            li: {
-              id: Math.floor(Math.random() * 1_000_000_000),
-              type: "hotels",
-              mode: "placeList",
-              heading: "Hotels and lodging",
-              date: null,
-              blocks: [block],
-              placeMarkerColor: "#7045af",
-              placeMarkerIcon: "bed",
-              text: { ops: [{ insert: "\n" }] },
-            },
-          },
-        ];
-    if (imageKeys.length > 0) {
-      ops.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
-    }
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const text = `Added ${detail.name} to "${trip.title}" · check-in ${args.check_in} → check-out ${args.check_out}.`;
+    const text = `Added ${detail.name} to "${tripTitle}" · check-in ${args.check_in} → check-out ${args.check_out}.`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/add-journal.ts
+++ b/src/tools/add-journal.ts
@@ -81,46 +81,13 @@ export async function addJournal(
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
     const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    // Tier 1: reuse a place the trip already references (itinerary or journal).
-    const existing = findTripPlaces(trip, args.place);
-    let place: PlaceData;
-    let linkedToTrip: boolean;
-
-    if (existing.length > 1) {
-      const lines = existing.slice(0, 10).map((p, i) => `  ${i + 1}. ${p.name}`).join("\n");
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.place}" matches ${existing.length} places already in "${trip.title}":\n${lines}\n\nRe-call with a more specific name.`,
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    if (existing.length === 1) {
-      place = existing[0]!;
-      linkedToTrip = true;
-    } else if (!args.allow_new_place) {
-      // Tier 2: not in the trip — prompt rather than silently adding a new place.
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.place}" isn't a place in "${trip.title}" yet. Add it to the trip first with wanderlog_add_place and then journal it, or re-call wanderlog_add_journal with allow_new_place: true to add it as a new (unplanned) journal place.`,
-          },
-        ],
-        isError: true,
-      };
-    } else {
-      // Override: search for the place and embed a fresh result.
-      const center = findTripCenter(trip, entry.geos);
+    let searchedPlace: PlaceData | undefined;
+    const existingBeforeLock = findTripPlaces(entry.snapshot, args.place);
+    if (args.allow_new_place && existingBeforeLock.length === 0) {
+      const center = findTripCenter(entry.snapshot, entry.geos);
       if (!center) {
         throw new WanderlogError(
-          `Cannot resolve a new place for the journal stop in "${trip.title}"`,
+          `Cannot resolve a new place for the journal stop in "${entry.snapshot.title}"`,
           "no_location_anchor",
           "This trip has no associated geo and no existing places to anchor the search. Add a place to the trip first.",
         );
@@ -133,7 +100,7 @@ export async function addJournal(
       });
       if (predictions.length === 0) {
         throw new WanderlogError(
-          `No place found matching "${args.place}" near ${trip.title}`,
+          `No place found matching "${args.place}" near ${entry.snapshot.title}`,
           "place_not_found",
           {
             hint: "Try a more specific name, or widen the search with wanderlog_search_places first.",
@@ -143,47 +110,82 @@ export async function addJournal(
           },
         );
       }
-      place = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
-      linkedToTrip = false;
+      searchedPlace = await ctx.rest.getPlaceDetails(predictions[0]!.place_id);
     }
 
-    const stops = getJournalStops(trip).map((m) => m.stop);
-    // Default to the day this place is scheduled on in the itinerary, else today.
-    const date =
-      args.date ?? placeItineraryDate(trip, place) ?? new Date().toISOString().slice(0, 10);
-    const time = args.time ?? "09:00";
-    const dateTime = `${date}T${time}${existingStopOffset(stops)}`;
-
-    const stop: Record<string, unknown> = {
-      id: generateBlockId(),
-      type: "confirmed",
-      title: args.title ?? place.name,
-      dateTime,
-      place,
-      media: [],
-    };
-    if (args.text) {
-      stop.text = { ops: [{ insert: args.text }] };
-    }
-
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "journal", "stops", stops.length],
-        li: stop,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const titleLabel = args.title ?? place.name;
-    const suffix = linkedToTrip
+    const result = await submitOp(ctx, args.trip_key, async (lockedEntry, submit) => {
+      const trip = lockedEntry.snapshot;
+      const existing = findTripPlaces(trip, args.place);
+      if (existing.length > 1) {
+        const lines = existing
+          .slice(0, 10)
+          .map((place, index) => `  ${index + 1}. ${place.name}`)
+          .join("\n");
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.place}" matches ${existing.length} places already in "${trip.title}":\n${lines}\n\nRe-call with a more specific name.`,
+              },
+            ],
+            isError: true,
+          },
+        };
+      }
+      if (existing.length === 0 && !args.allow_new_place) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.place}" isn't a place in "${trip.title}" yet. Add it to the trip first with wanderlog_add_place and then journal it, or re-call wanderlog_add_journal with allow_new_place: true to add it as a new (unplanned) journal place.`,
+              },
+            ],
+            isError: true,
+          },
+        };
+      }
+      const place = existing[0] ?? searchedPlace;
+      if (!place) {
+        throw new WanderlogError(
+          `No place found matching "${args.place}" near ${trip.title}`,
+          "place_not_found",
+        );
+      }
+      const linkedToTrip = existing.length === 1;
+      const stops = getJournalStops(trip).map((match) => match.stop);
+      const date =
+        args.date ?? placeItineraryDate(trip, place) ?? new Date().toISOString().slice(0, 10);
+      const time = args.time ?? "09:00";
+      const stop: Record<string, unknown> = {
+        id: generateBlockId(),
+        type: "confirmed",
+        title: args.title ?? place.name,
+        dateTime: `${date}T${time}${existingStopOffset(stops)}`,
+        place,
+        media: [],
+      };
+      if (args.text) stop.text = { ops: [{ insert: args.text }] };
+      const ops: Json0Op[] = [
+        {
+          p: ["itinerary", "journal", "stops", stops.length],
+          li: stop,
+        },
+      ];
+      await submit(ops);
+      return { date, linkedToTrip, place, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
+    const titleLabel = args.title ?? result.place.name;
+    const suffix = result.linkedToTrip
       ? " (reused a place already in your trip)"
-      : ` (new place — ${place.name} wasn't in your itinerary)`;
+      : ` (new place — ${result.place.name} wasn't in your itinerary)`;
     return {
       content: [
         {
           type: "text",
-          text: `Added journal stop "${titleLabel}" (${date}) at ${place.name} in "${trip.title}"${suffix}.`,
+          text: `Added journal stop "${titleLabel}" (${result.date}) at ${result.place.name} in "${result.tripTitle}"${suffix}.`,
         },
       ],
     };

--- a/src/tools/add-note.ts
+++ b/src/tools/add-note.ts
@@ -5,6 +5,7 @@ import type { Json0Op } from "../ot/apply.js";
 import type { TripPlan } from "../types.js";
 import {
   buildNoteBlock,
+  findBlockById,
   findSectionByRef,
   findTargetSection,
   requireUserId,
@@ -93,32 +94,48 @@ export async function addNote(
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
     const userId = requireUserId(ctx);
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const target = evaluateTargetSection(trip, args);
+      const block = buildNoteBlock(userId);
+      const insertOps: Json0Op[] = [
+        {
+          p: [
+            "itinerary",
+            "sections",
+            target.index,
+            "blocks",
+            target.section.blocks.length,
+          ],
+          li: block,
+        },
+      ];
+      await submit(insertOps);
 
-    const target = evaluateTargetSection(trip, args);
-
-    // Step 1: Insert the note block with placeholder text
-    const block = buildNoteBlock(userId);
-    const insertIndex = target.section.blocks.length;
-    const blockPath = ["itinerary", "sections", target.index, "blocks", insertIndex];
-    const insertOps: Json0Op[] = [{ p: blockPath, li: block }];
-
-    await submitOp(ctx, args.trip_key, insertOps);
-
-    // Step 2: Set the note text via rich-text subtype op
-    const textOps: Json0Op[] = [
-      {
-        p: [...blockPath, "text"],
-        t: "rich-text",
-        o: [{ insert: `${args.text}\n` }],
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, textOps);
+      const inserted = findBlockById(entry.snapshot, block.id as number);
+      if (!inserted || inserted.block.type !== "note") {
+        throw new WanderlogError("Inserted note could not be found", "stale_target");
+      }
+      const textOps: Json0Op[] = [
+        {
+          p: [
+            "itinerary",
+            "sections",
+            inserted.sectionIndex,
+            "blocks",
+            inserted.blockIndex,
+            "text",
+          ],
+          t: "rich-text",
+          o: [{ insert: `${args.text}\n` }],
+        },
+      ];
+      await submit(textOps);
+      return { targetLabel: target.label, tripTitle: entry.snapshot.title };
+    });
 
     const preview = args.text.length > 60 ? `${args.text.slice(0, 57)}…` : args.text;
-    const text = `Added note "${preview}" to ${target.label} in "${trip.title}".`;
+    const text = `Added note "${preview}" to ${result.targetLabel} in "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/add-place.ts
+++ b/src/tools/add-place.ts
@@ -6,6 +6,7 @@ import { resolveDay } from "../resolvers/day.js";
 import type { PlaceData } from "../types.js";
 import {
   buildPlaceBlock,
+  findBlockById,
   findDaySectionByDate,
   findPlacesToVisitSection,
   findSectionByRef,
@@ -89,49 +90,10 @@ export async function addPlace(
     validateTimeInputs(args.start_time, args.end_time);
     const userId = requireUserId(ctx);
     const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    // Resolve target sections. entry.snapshot is replaced after each submitOp
-    // (applyLocalOp returns a new object), so section indices are pre-computed
-    // once here — they stay stable because block inserts don't shift sections.
-    type Target = { sectionIndex: number; label: string };
-    const targets: Target[] = [];
-
-    if (args.day) {
-      const daySection = resolveDay(trip, args.day);
-      const found = findDaySectionByDate(trip, daySection.date!);
-      if (!found) {
-        throw new WanderlogValidationError(`Day ${args.day} not found in trip`);
-      }
-      targets.push({ sectionIndex: found.index, label: `day ${daySection.date}` });
-    }
-
-    if (args.section) {
-      const found = findSectionByRef(trip, args.section);
-      if (!found) {
-        throw new WanderlogValidationError(
-          `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
-        );
-      }
-      targets.push({ sectionIndex: found.index, label: `section "${args.section}"` });
-    }
-
-    if (targets.length === 0) {
-      const places = findPlacesToVisitSection(trip);
-      if (!places) {
-        throw new WanderlogError(
-          "Trip has no 'Places to visit' list",
-          "no_places_section",
-          "This is unexpected — Wanderlog usually creates one automatically. Try adding to a specific day instead.",
-        );
-      }
-      targets.push({ sectionIndex: places.index, label: "places to visit" });
-    }
-
-    const center = findTripCenter(trip, entry.geos);
+    const center = findTripCenter(entry.snapshot, entry.geos);
     if (!center) {
       throw new WanderlogValidationError(
-        `Cannot add places to "${trip.title}" because no location anchor is available`,
+        `Cannot add places to "${entry.snapshot.title}" because no location anchor is available`,
         "This trip has no associated geo and no existing places. Add a place via the Wanderlog UI first.",
       );
     }
@@ -143,7 +105,7 @@ export async function addPlace(
     });
     if (predictions.length === 0) {
       throw new WanderlogError(
-        `No place found matching "${args.place}" near ${trip.title}`,
+        `No place found matching "${args.place}" near ${entry.snapshot.title}`,
         "place_not_found",
         {
           hint: "Try a more specific name, or widen the search with wanderlog_search_places first.",
@@ -158,45 +120,114 @@ export async function addPlace(
     const detail: PlaceData = await ctx.rest.getPlaceDetails(topPrediction.place_id);
     const imageKeys = await ctx.rest.getPlacePhotos(detail);
 
-    // Insert the place into each target. entry.snapshot is read fresh each
-    // iteration so blocks.length is accurate even when both targets are the
-    // same section (second block must go at N+1, not N).
-    for (const target of targets) {
-      const currentSnapshot = entry.snapshot;
-      const insertIndex = currentSnapshot.itinerary.sections[target.sectionIndex]!.blocks.length;
-      const blockPath = ["itinerary", "sections", target.sectionIndex, "blocks", insertIndex];
+    const mutation = await submitOp(ctx, args.trip_key, async (lockedEntry, submit) => {
+      const trip = lockedEntry.snapshot;
+      type Target = { sectionId: number; label: string };
+      const targets: Target[] = [];
 
-      // Build the block WITHOUT timing — timing is set via separate oi ops
-      // to match the Wanderlog UI's two-step pattern (insert block, then set fields).
-      const block = buildPlaceBlock(detail, userId);
-      const insertOps: Json0Op[] = [{ p: blockPath, li: block }];
-      // iOS/iPadOS native apps render thumbnails strictly from `imageKeys`.
-      // Submit together with the `li` so no client ever sees a keyless block.
-      if (imageKeys.length > 0) {
-        insertOps.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
+      if (args.day) {
+        const daySection = resolveDay(trip, args.day);
+        const found = findDaySectionByDate(trip, daySection.date!);
+        if (!found) {
+          throw new WanderlogValidationError(`Day ${args.day} not found in trip`);
+        }
+        targets.push({ sectionId: found.section.id, label: `day ${daySection.date}` });
       }
-      await submitOp(ctx, args.trip_key, insertOps);
-
-      if (args.note) {
-        await submitOp(ctx, args.trip_key, [
-          {
-            p: [...blockPath, "text"],
-            t: "rich-text",
-            o: [{ insert: `${args.note}\n` }],
-          },
-        ]);
+      if (args.section) {
+        const found = findSectionByRef(trip, args.section);
+        if (!found) {
+          throw new WanderlogValidationError(
+            `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+          );
+        }
+        targets.push({ sectionId: found.section.id, label: `section "${args.section}"` });
+      }
+      if (targets.length === 0) {
+        const places = findPlacesToVisitSection(trip);
+        if (!places) {
+          throw new WanderlogError(
+            "Trip has no 'Places to visit' list",
+            "no_places_section",
+            "This is unexpected — Wanderlog usually creates one automatically. Try adding to a specific day instead.",
+          );
+        }
+        targets.push({ sectionId: places.section.id, label: "places to visit" });
       }
 
-      if (args.start_time || args.end_time) {
-        const timeOps: Json0Op[] = [];
-        if (args.start_time) timeOps.push({ p: [...blockPath, "startTime"], oi: args.start_time });
-        if (args.end_time) timeOps.push({ p: [...blockPath, "endTime"], oi: args.end_time });
-        await submitOp(ctx, args.trip_key, timeOps);
-      }
-    }
+      for (const target of targets) {
+        const sectionIndex = lockedEntry.snapshot.itinerary.sections.findIndex(
+          (section) => section.id === target.sectionId,
+        );
+        if (sectionIndex < 0) {
+          throw new WanderlogError("Target section moved or was removed", "stale_target");
+        }
+        const section = lockedEntry.snapshot.itinerary.sections[sectionIndex]!;
+        const block = buildPlaceBlock(detail, userId);
+        const blockPath = [
+          "itinerary",
+          "sections",
+          sectionIndex,
+          "blocks",
+          section.blocks.length,
+        ];
+        const insertOps: Json0Op[] = [{ p: blockPath, li: block }];
+        if (imageKeys.length > 0) {
+          insertOps.push({ p: [...blockPath, "imageKeys"], oi: imageKeys });
+        }
+        await submit(insertOps);
 
-    const labelList = targets.map((t) => t.label).join(" and ");
-    const parts = [`Added ${detail.name} to ${labelList} in "${trip.title}".`];
+        if (args.note) {
+          const inserted = findBlockById(lockedEntry.snapshot, block.id);
+          if (!inserted || inserted.block.type !== "place") {
+            throw new WanderlogError("Inserted place could not be found", "stale_target");
+          }
+          await submit([
+            {
+              p: [
+                "itinerary",
+                "sections",
+                inserted.sectionIndex,
+                "blocks",
+                inserted.blockIndex,
+                "text",
+              ],
+              t: "rich-text",
+              o: [{ insert: `${args.note}\n` }],
+            },
+          ]);
+        }
+
+        if (args.start_time || args.end_time) {
+          const inserted = findBlockById(lockedEntry.snapshot, block.id);
+          if (!inserted || inserted.block.type !== "place") {
+            throw new WanderlogError("Inserted place could not be found", "stale_target");
+          }
+          const currentPath = [
+            "itinerary",
+            "sections",
+            inserted.sectionIndex,
+            "blocks",
+            inserted.blockIndex,
+          ];
+          const timeOps: Json0Op[] = [];
+          if (args.start_time) {
+            timeOps.push({ p: [...currentPath, "startTime"], oi: args.start_time });
+          }
+          if (args.end_time) {
+            timeOps.push({ p: [...currentPath, "endTime"], oi: args.end_time });
+          }
+          await submit(timeOps);
+        }
+      }
+      return {
+        labelList: targets.map((target) => target.label).join(" and "),
+        tripTitle: trip.title,
+      };
+    });
+
+    const parts = [
+      `Added ${detail.name} to ${mutation.labelList} in "${mutation.tripTitle}".`,
+    ];
     if (args.start_time) {
       parts.push(`Scheduled: ${args.start_time}${args.end_time ? `–${args.end_time}` : ""}.`);
     }
@@ -214,4 +245,3 @@ export async function addPlace(
     return { content: [{ type: "text", text: msg }], isError: true };
   }
 }
-

--- a/src/tools/add-section.ts
+++ b/src/tools/add-section.ts
@@ -52,35 +52,33 @@ export async function addSection(
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
     requireUserId(ctx);
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    let insertIndex: number;
-    if (args.after_section) {
-      const found = findSectionByRef(trip, args.after_section);
-      if (!found) {
-        throw new WanderlogValidationError(
-          `Section "${args.after_section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
-        );
-      }
-      insertIndex = found.index + 1;
-    } else {
-      insertIndex = trip.itinerary.sections.length;
-    }
-
     const heading = args.heading ?? "";
-    const section = buildSectionObject(heading);
-
-    const ops: Json0Op[] = [
-      { p: ["itinerary", "sections", insertIndex], li: section },
-    ];
-    await submitOp(ctx, args.trip_key, ops);
+    const tripTitle = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      let insertIndex: number;
+      if (args.after_section) {
+        const found = findSectionByRef(trip, args.after_section);
+        if (!found) {
+          throw new WanderlogValidationError(
+            `Section "${args.after_section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+          );
+        }
+        insertIndex = found.index + 1;
+      } else {
+        insertIndex = trip.itinerary.sections.length;
+      }
+      const ops: Json0Op[] = [
+        { p: ["itinerary", "sections", insertIndex], li: buildSectionObject(heading) },
+      ];
+      await submit(ops);
+      return trip.title;
+    });
 
     const headingLabel = heading || "(untitled)";
     const positionLabel = args.after_section
       ? `after "${args.after_section}"`
       : "at the end";
-    const text = `Added section "${headingLabel}" ${positionLabel} in "${trip.title}".`;
+    const text = `Added section "${headingLabel}" ${positionLabel} in "${tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/add-transit.ts
+++ b/src/tools/add-transit.ts
@@ -80,11 +80,9 @@ export async function addTransit(
 
     const userId = requireUserId(ctx);
     const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
     const [fromPlace, toPlace] = await Promise.all([
-      resolveEndpointPlace(ctx, trip, entry.geos, args.from),
-      resolveEndpointPlace(ctx, trip, entry.geos, args.to),
+      resolveEndpointPlace(ctx, entry.snapshot, entry.geos, args.from),
+      resolveEndpointPlace(ctx, entry.snapshot, entry.geos, args.to),
     ]);
 
     const depart: TransitEndpoint = {
@@ -98,18 +96,19 @@ export async function addTransit(
       time: args.arrive_time,
     };
 
-    const block = buildTransitBlock(args.type, userId, {
-      carrier: args.carrier,
-      depart,
-      arrive,
-      confirmationNumber: args.confirmation_number,
-      notes: args.notes,
+    const tripTitle = await submitOp(ctx, args.trip_key, async (lockedEntry, submit) => {
+      const block = buildTransitBlock(args.type, userId, {
+        carrier: args.carrier,
+        depart,
+        arrive,
+        confirmationNumber: args.confirmation_number,
+        notes: args.notes,
+      });
+      await submit([sectionInsertOp(lockedEntry.snapshot, "transit", block)]);
+      return lockedEntry.snapshot.title;
     });
 
-    const op = sectionInsertOp(trip, "transit", block);
-    await submitOp(ctx, args.trip_key, [op]);
-
-    const text = `Added ${args.type} ${args.carrier} to "${trip.title}" · ${fromPlace.name} → ${toPlace.name} · ${args.depart_date} ${args.depart_time}.`;
+    const text = `Added ${args.type} ${args.carrier} to "${tripTitle}" · ${fromPlace.name} → ${toPlace.name} · ${args.depart_date} ${args.depart_time}.`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/annotate-place.ts
+++ b/src/tools/annotate-place.ts
@@ -4,7 +4,7 @@ import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import { resolvePlaceRef } from "../resolvers/place-ref.js";
 import { isPlaceBlock } from "../types.js";
-import { submitOp, validateTimeInputs } from "./shared.js";
+import { assertBlockAtPath, findBlockById, submitOp, validateTimeInputs } from "./shared.js";
 
 export const annotatePlaceInputSchema = {
   trip_key: z
@@ -64,66 +64,118 @@ export async function annotatePlace(
       );
     }
 
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    const result = resolvePlaceRef(trip, args.place);
-    if (result.kind === "none") {
-      throw new WanderlogError(
-        `No place matching "${args.place}" found in "${trip.title}"`,
-        "place_ref_not_found",
-        {
-          hint: "Check the place name or use wanderlog_get_trip to see what's in the itinerary.",
-          followUps: [
-            `Call wanderlog_get_trip with trip_key "${args.trip_key}" to see all places.`,
-          ],
-        },
-      );
-    }
-    if (result.kind === "ambiguous") {
-      const lines = result.candidates.map((c, i) => {
-        const name = isPlaceBlock(c.block) ? c.block.place.name : `block #${c.block.id}`;
-        const loc = c.section.date ? `day ${c.section.date}` : c.section.heading || "unscheduled";
-        return `  ${i + 1}. ${name} (${loc})`;
-      });
-      const text = `Multiple places match "${args.place}":\n${lines.join("\n")}\n\nRetry with a more specific reference or an ordinal prefix (e.g. "1st ${args.place}").`;
-      return { content: [{ type: "text", text }] };
-    }
-
-    const { sectionIndex, blockIndex, block } = result.match;
-    const blockPath = ["itinerary", "sections", sectionIndex, "blocks", blockIndex];
-    const placeName = isPlaceBlock(block) ? block.place.name : `block #${block.id}`;
-
-    // Set inline note via rich-text subtype op
-    if (args.note) {
-      const textOps: Json0Op[] = [
-        {
-          p: [...blockPath, "text"],
-          t: "rich-text",
-          o: [{ insert: `${args.note}\n` }],
-        },
-      ];
-      await submitOp(ctx, args.trip_key, textOps);
-    }
-
-    // Set timing — use od+oi when the field already exists, plain oi when it doesn't
-    if (args.start_time || args.end_time) {
-      const timeOps: Json0Op[] = [];
-      const existingBlock = block as Record<string, unknown>;
-      if (args.start_time) {
-        const op: Json0Op = { p: [...blockPath, "startTime"], oi: args.start_time };
-        if ("startTime" in existingBlock) op.od = existingBlock.startTime as string | null;
-        timeOps.push(op);
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const resolved = resolvePlaceRef(entry.snapshot, args.place);
+      if (resolved.kind === "none") {
+        throw new WanderlogError(
+          `No place matching "${args.place}" found in "${entry.snapshot.title}"`,
+          "place_ref_not_found",
+          {
+            hint: "Check the place name or use wanderlog_get_trip to see what's in the itinerary.",
+            followUps: [
+              `Call wanderlog_get_trip with trip_key "${args.trip_key}" to see all places.`,
+            ],
+          },
+        );
       }
-      if (args.end_time) {
-        const op: Json0Op = { p: [...blockPath, "endTime"], oi: args.end_time };
-        if ("endTime" in existingBlock) op.od = existingBlock.endTime as string | null;
-        timeOps.push(op);
+      if (resolved.kind === "ambiguous") {
+        const lines = resolved.candidates.map((c, i) => {
+          const name = isPlaceBlock(c.block) ? c.block.place.name : `block #${c.block.id}`;
+          const loc = c.section.date ? `day ${c.section.date}` : c.section.heading || "unscheduled";
+          return `  ${i + 1}. ${name} (${loc})`;
+        });
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `Multiple places match "${args.place}":\n${lines.join("\n")}\n\nRetry with a more specific reference or an ordinal prefix (e.g. "1st ${args.place}").`,
+              },
+            ],
+          },
+        };
       }
-      await submitOp(ctx, args.trip_key, timeOps);
-    }
 
-    const parts = [`Updated ${placeName} in "${trip.title}".`];
+      const blockId = resolved.match.block.id;
+      const placeName = isPlaceBlock(resolved.match.block)
+        ? resolved.match.block.place.name
+        : `block #${blockId}`;
+
+      if (args.note) {
+        const current = findBlockById(entry.snapshot, blockId);
+        if (!current) throw new WanderlogError("Place moved or was removed", "stale_target");
+        assertBlockAtPath(entry.snapshot, current.sectionIndex, current.blockIndex, blockId);
+        const textOps: Json0Op[] = [
+          {
+            p: [
+              "itinerary",
+              "sections",
+              current.sectionIndex,
+              "blocks",
+              current.blockIndex,
+              "text",
+            ],
+            t: "rich-text",
+            o: [{ insert: `${args.note}\n` }],
+          },
+        ];
+        await submit(textOps);
+      }
+
+      if (args.start_time || args.end_time) {
+        const current = findBlockById(entry.snapshot, blockId);
+        if (!current) throw new WanderlogError("Place moved or was removed", "stale_target");
+        const block = assertBlockAtPath(
+          entry.snapshot,
+          current.sectionIndex,
+          current.blockIndex,
+          blockId,
+        );
+        const blockPath = [
+          "itinerary",
+          "sections",
+          current.sectionIndex,
+          "blocks",
+          current.blockIndex,
+        ];
+        const timeOps: Json0Op[] = [];
+        const existingBlock = block as Record<string, unknown>;
+        if (args.start_time) {
+          const op: Json0Op = { p: [...blockPath, "startTime"], oi: args.start_time };
+          if ("startTime" in existingBlock) op.od = existingBlock.startTime as string | null;
+          timeOps.push(op);
+        }
+        if (args.end_time) {
+          const op: Json0Op = { p: [...blockPath, "endTime"], oi: args.end_time };
+          if ("endTime" in existingBlock) op.od = existingBlock.endTime as string | null;
+          timeOps.push(op);
+        }
+        await submit(timeOps);
+      }
+
+      const updated = findBlockById(entry.snapshot, blockId)?.block;
+      if (!updated) {
+        throw new WanderlogError("Updated place could not be verified", "stale_target");
+      }
+      const record = updated as Record<string, unknown>;
+      const textValue = record.text as
+        | { ops?: Array<{ insert?: unknown }> }
+        | undefined;
+      const noteText = textValue?.ops
+        ?.map((op) => (typeof op.insert === "string" ? op.insert : ""))
+        .join("");
+      if (
+        (args.note && !noteText?.includes(args.note)) ||
+        (args.start_time && record.startTime !== args.start_time) ||
+        (args.end_time && record.endTime !== args.end_time)
+      ) {
+        throw new WanderlogError("Updated place fields could not be verified", "stale_target");
+      }
+      return { placeName, tripTitle: entry.snapshot.title };
+    });
+    if ("response" in result && result.response) return result.response;
+
+    const parts = [`Updated ${result.placeName} in "${result.tripTitle}".`];
     if (args.start_time) {
       parts.push(`Time: ${args.start_time}${args.end_time ? `–${args.end_time}` : ""}.`);
     }

--- a/src/tools/delete-section.ts
+++ b/src/tools/delete-section.ts
@@ -44,43 +44,39 @@ export async function deleteSection(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    const found = findSectionByRef(trip, args.section);
-    if (!found) {
-      throw new WanderlogValidationError(
-        `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
-      );
-    }
-
-    const { index, section } = found;
-
-    if (section.mode === "dayPlan") {
-      throw new WanderlogValidationError(
-        `Day sections cannot be deleted here. Use wanderlog_update_trip_dates to change the trip's date range instead.`,
-      );
-    }
-
-    if (findPlacesToVisitSection(trip)?.index === index) {
-      throw new WanderlogValidationError(
-        `The "Places to visit" section cannot be deleted — it is the trip's default place list.`,
-      );
-    }
-
-    if (SYSTEM_SECTION_TYPES.has(section.type)) {
-      throw new WanderlogValidationError(
-        `The "${section.heading || section.type}" section is a system section and cannot be deleted.`,
-      );
-    }
-
-    const ops: Json0Op[] = [
-      { p: ["itinerary", "sections", index], ld: section },
-    ];
-    await submitOp(ctx, args.trip_key, ops);
-
-    const label = section.heading || "(untitled)";
-    const text = `Deleted section "${label}" from "${trip.title}".`;
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const found = findSectionByRef(trip, args.section);
+      if (!found) {
+        throw new WanderlogValidationError(
+          `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+        );
+      }
+      const { index, section } = found;
+      if (section.mode === "dayPlan") {
+        throw new WanderlogValidationError(
+          `Day sections cannot be deleted here. Use wanderlog_update_trip_dates to change the trip's date range instead.`,
+        );
+      }
+      if (findPlacesToVisitSection(trip)?.index === index) {
+        throw new WanderlogValidationError(
+          `The "Places to visit" section cannot be deleted — it is the trip's default place list.`,
+        );
+      }
+      if (SYSTEM_SECTION_TYPES.has(section.type)) {
+        throw new WanderlogValidationError(
+          `The "${section.heading || section.type}" section is a system section and cannot be deleted.`,
+        );
+      }
+      const sectionId = section.id;
+      const ops: Json0Op[] = [{ p: ["itinerary", "sections", index], ld: section }];
+      await submit(ops);
+      if (entry.snapshot.itinerary.sections.some((candidate) => candidate.id === sectionId)) {
+        throw new WanderlogError("Deleted section is still present", "stale_target");
+      }
+      return { label: section.heading || "(untitled)", tripTitle: trip.title };
+    });
+    const text = `Deleted section "${result.label}" from "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/edit-expense.ts
+++ b/src/tools/edit-expense.ts
@@ -175,51 +175,54 @@ export async function editExpense(
       );
     }
 
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const matches = findExpenseMatches(trip, {
-      description: args.description,
-      date: args.date,
-      amount: args.amount,
-      currency: args.currency,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const matches = findExpenseMatches(trip, {
+        description: args.description,
+        date: args.date,
+        amount: args.amount,
+        currency: args.currency,
+      });
+      if (matches.length === 0) {
+        throw new WanderlogNotFoundError("Expense", args.description);
+      }
+      if (matches.length > 1) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.description}" matches ${matches.length} expenses:\n${formatCandidateList(matches)}\n\nRe-call with a more specific description, or add a date / amount / currency filter to pick one.`,
+              },
+            ],
+            isError: true,
+          },
+        };
+      }
+      const { index, expense } = matches[0]!;
+      const { ops, changes } = buildEditOps(expense, index, args);
+      if (ops.length === 0) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `No changes — ${formatExpense(expense)} already has those values.`,
+              },
+            ],
+          },
+        };
+      }
+      await submit(ops);
+      return { changes, expense, tripTitle: trip.title };
     });
-
-    if (matches.length === 0) {
-      throw new WanderlogNotFoundError("Expense", args.description);
-    }
-
-    if (matches.length > 1) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.description}" matches ${matches.length} expenses:\n${formatCandidateList(matches)}\n\nRe-call with a more specific description, or add a date / amount / currency filter to pick one.`,
-          },
-        ],
-        isError: true,
-      };
-    }
-
-    const { index, expense } = matches[0]!;
-    const { ops, changes } = buildEditOps(expense, index, args);
-
-    if (ops.length === 0) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `No changes — ${formatExpense(expense)} already has those values.`,
-          },
-        ],
-      };
-    }
-
-    await submitOp(ctx, args.trip_key, ops);
+    if ("response" in result && result.response) return result.response;
 
     return {
       content: [
         {
           type: "text",
-          text: `Updated expense ${formatExpense(expense)} in "${trip.title}": ${changes.join(", ")}.`,
+          text: `Updated expense ${formatExpense(result.expense)} in "${result.tripTitle}": ${result.changes.join(", ")}.`,
         },
       ],
     };

--- a/src/tools/edit-journal.ts
+++ b/src/tools/edit-journal.ts
@@ -129,63 +129,72 @@ export async function editJournal(
       );
     }
 
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const ops: Json0Op[] = [];
-    const changes: string[] = [];
-    let stopLabel = "";
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const ops: Json0Op[] = [];
+      const changes: string[] = [];
+      let stopLabel = "";
 
-    if (hasStopEdit) {
-      if (!args.title) {
-        throw new WanderlogValidationError(
-          "Provide 'title' to identify which journal stop to edit.",
-        );
-      }
-      const matches = findStopMatches(trip, { title: args.title, date: args.date });
-      if (matches.length === 0) {
-        throw new WanderlogNotFoundError("Journal stop", args.title);
-      }
-      if (matches.length > 1) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `"${args.title}" matches ${matches.length} journal stops:\n${formatStopCandidateList(matches)}\n\nRe-call with a more specific title, or add a date filter to pick one.`,
+      if (hasStopEdit) {
+        if (!args.title) {
+          throw new WanderlogValidationError(
+            "Provide 'title' to identify which journal stop to edit.",
+          );
+        }
+        const matches = findStopMatches(trip, { title: args.title, date: args.date });
+        if (matches.length === 0) {
+          throw new WanderlogNotFoundError("Journal stop", args.title);
+        }
+        if (matches.length > 1) {
+          return {
+            response: {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `"${args.title}" matches ${matches.length} journal stops:\n${formatStopCandidateList(matches)}\n\nRe-call with a more specific title, or add a date filter to pick one.`,
+                },
+              ],
+              isError: true,
             },
-          ],
-          isError: true,
+          };
+        }
+        const { index, stop } = matches[0]!;
+        stopLabel = formatStop(stop);
+        const built = buildStopOps(stop, index, args);
+        ops.push(...built.ops);
+        changes.push(...built.changes);
+      }
+
+      if (hasSummaryEdit) {
+        const current = trip.itinerary.journal?.summary;
+        if (args.new_summary !== current) {
+          ops.push(replaceField(["itinerary", "journal", "summary"], current, args.new_summary));
+          changes.push("journal summary");
+        }
+      }
+
+      if (ops.length === 0) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `No changes — those values already match in "${trip.title}".`,
+              },
+            ],
+          },
         };
       }
-      const { index, stop } = matches[0]!;
-      stopLabel = formatStop(stop);
-      const built = buildStopOps(stop, index, args);
-      ops.push(...built.ops);
-      changes.push(...built.changes);
-    }
-
-    if (hasSummaryEdit) {
-      const current = trip.itinerary.journal?.summary;
-      if (args.new_summary !== current) {
-        ops.push(replaceField(["itinerary", "journal", "summary"], current, args.new_summary));
-        changes.push("journal summary");
-      }
-    }
-
-    if (ops.length === 0) {
-      return {
-        content: [
-          { type: "text", text: `No changes — those values already match in "${trip.title}".` },
-        ],
-      };
-    }
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const target = stopLabel ? `stop ${stopLabel}` : "journal";
+      await submit(ops);
+      return { stopLabel, changes, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
+    const target = result.stopLabel ? `stop ${result.stopLabel}` : "journal";
     return {
       content: [
         {
           type: "text",
-          text: `Updated ${target} in "${trip.title}": ${changes.join(", ")}.`,
+          text: `Updated ${target} in "${result.tripTitle}": ${result.changes.join(", ")}.`,
         },
       ],
     };

--- a/src/tools/edit-note.ts
+++ b/src/tools/edit-note.ts
@@ -195,60 +195,62 @@ export async function editNote(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const targets = findEditTargets(trip, args.old_text, args.day);
-
-    if (targets.length === 0) {
-      throw new WanderlogNotFoundError("Note", args.old_text);
-    }
-
-    if (targets.length > 1) {
-      const lines = targets
-        .slice(0, 5)
-        .map((t, i) => `  ${i + 1}. ${t.preview}`)
-        .join("\n");
-      const suffix = targets.length > 5 ? `\n  (${targets.length - 5} more…)` : "";
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.old_text}" matches ${targets.length} notes:\n${lines}${suffix}\n\nCall again with a more specific substring to identify the one you want.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const targets = findEditTargets(trip, args.old_text, args.day);
+      if (targets.length === 0) {
+        throw new WanderlogNotFoundError("Note", args.old_text);
+      }
+      if (targets.length > 1) {
+        const lines = targets
+          .slice(0, 5)
+          .map((target, index) => `  ${index + 1}. ${target.preview}`)
+          .join("\n");
+        const suffix = targets.length > 5 ? `\n  (${targets.length - 5} more…)` : "";
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.old_text}" matches ${targets.length} notes:\n${lines}${suffix}\n\nCall again with a more specific substring to identify the one you want.`,
+              },
+            ],
+            isError: true,
           },
-        ],
-        isError: true,
-      };
-    }
-
-    const target = targets[0]!;
-
-    if (target.kind === "rich-text" && target.crossesBoundary) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Cannot replace "${args.old_text}": the match crosses a formatting boundary (e.g. a link or bold section). Use a more specific substring that stays within one formatting run.`,
+        };
+      }
+      const target = targets[0]!;
+      if (target.kind === "rich-text" && target.crossesBoundary) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `Cannot replace "${args.old_text}": the match crosses a formatting boundary (e.g. a link or bold section). Use a more specific substring that stays within one formatting run.`,
+              },
+            ],
+            isError: true,
           },
-        ],
-        isError: true,
-      };
-    }
-
-    let ops: Json0Op[];
-    if (target.kind === "rich-text") {
-      const deltaOps: Array<Record<string, unknown>> = [];
-      if (target.offset > 0) deltaOps.push({ retain: target.offset });
-      deltaOps.push({ delete: target.matchedLen });
-      if (args.new_text) deltaOps.push({ insert: args.new_text });
-      ops = [{ p: target.fieldPath, t: "rich-text", o: deltaOps }];
-    } else {
-      const newValue =
-        target.oldValue.slice(0, target.offset) +
-        args.new_text +
-        target.oldValue.slice(target.offset + target.matchedLen);
-      ops = [{ p: target.fieldPath, od: target.oldValue, oi: newValue }];
-    }
-
-    await submitOp(ctx, args.trip_key, ops);
+        };
+      }
+      let ops: Json0Op[];
+      if (target.kind === "rich-text") {
+        const deltaOps: Array<Record<string, unknown>> = [];
+        if (target.offset > 0) deltaOps.push({ retain: target.offset });
+        deltaOps.push({ delete: target.matchedLen });
+        if (args.new_text) deltaOps.push({ insert: args.new_text });
+        ops = [{ p: target.fieldPath, t: "rich-text", o: deltaOps }];
+      } else {
+        const newValue =
+          target.oldValue.slice(0, target.offset) +
+          args.new_text +
+          target.oldValue.slice(target.offset + target.matchedLen);
+        ops = [{ p: target.fieldPath, od: target.oldValue, oi: newValue }];
+      }
+      await submit(ops);
+      return { targetLabel: target.label, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
 
     const oldPreview = previewText(args.old_text);
     const newPreview = previewText(args.new_text || "(empty)");
@@ -256,7 +258,7 @@ export async function editNote(
       content: [
         {
           type: "text",
-          text: `Updated ${target.label} in "${trip.title}". Changed "${oldPreview}" → "${newPreview}".`,
+          text: `Updated ${result.targetLabel} in "${result.tripTitle}". Changed "${oldPreview}" → "${newPreview}".`,
         },
       ],
     };

--- a/src/tools/remove-expense.ts
+++ b/src/tools/remove-expense.ts
@@ -54,45 +54,48 @@ export async function removeExpense(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const matches = findExpenseMatches(trip, {
-      description: args.description,
-      date: args.date,
-      amount: args.amount,
-      currency: args.currency,
-    });
-
-    if (matches.length === 0) {
-      throw new WanderlogNotFoundError("Expense", args.description);
-    }
-
-    if (matches.length > 1) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.description}" matches ${matches.length} expenses:\n${formatCandidateList(matches)}\n\nRe-call with a more specific description, or add a date / amount / currency filter to pick one.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const matches = findExpenseMatches(trip, {
+        description: args.description,
+        date: args.date,
+        amount: args.amount,
+        currency: args.currency,
+      });
+      if (matches.length === 0) {
+        throw new WanderlogNotFoundError("Expense", args.description);
+      }
+      if (matches.length > 1) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.description}" matches ${matches.length} expenses:\n${formatCandidateList(matches)}\n\nRe-call with a more specific description, or add a date / amount / currency filter to pick one.`,
+              },
+            ],
+            isError: true,
           },
-        ],
-        isError: true,
-      };
-    }
-
-    const { index, expense } = matches[0]!;
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "budget", "expenses", index],
-        ld: expense,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
+        };
+      }
+      const { index, expense } = matches[0]!;
+      const expenseId = expense.id;
+      const ops: Json0Op[] = [
+        { p: ["itinerary", "budget", "expenses", index], ld: expense },
+      ];
+      await submit(ops);
+      if (entry.snapshot.itinerary.budget?.expenses?.some((item) => item.id === expenseId)) {
+        throw new WanderlogError("Removed expense is still present", "stale_target");
+      }
+      return { expense, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
 
     return {
       content: [
         {
           type: "text",
-          text: `Removed expense ${formatExpense(expense)} from "${trip.title}".`,
+          text: `Removed expense ${formatExpense(result.expense)} from "${result.tripTitle}".`,
         },
       ],
     };

--- a/src/tools/remove-journal.ts
+++ b/src/tools/remove-journal.ts
@@ -37,38 +37,44 @@ export async function removeJournal(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const matches = findStopMatches(trip, { title: args.title, date: args.date });
-
-    if (matches.length === 0) {
-      throw new WanderlogNotFoundError("Journal stop", args.title);
-    }
-
-    if (matches.length > 1) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.title}" matches ${matches.length} journal stops:\n${formatStopCandidateList(matches)}\n\nRe-call with a more specific title, or add a date filter to pick one.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const matches = findStopMatches(trip, { title: args.title, date: args.date });
+      if (matches.length === 0) {
+        throw new WanderlogNotFoundError("Journal stop", args.title);
+      }
+      if (matches.length > 1) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.title}" matches ${matches.length} journal stops:\n${formatStopCandidateList(matches)}\n\nRe-call with a more specific title, or add a date filter to pick one.`,
+              },
+            ],
+            isError: true,
           },
-        ],
-        isError: true,
-      };
-    }
-
-    const { index, stop } = matches[0]!;
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "journal", "stops", index],
-        ld: stop,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
+        };
+      }
+      const { index, stop } = matches[0]!;
+      const stopId = stop.id;
+      const ops: Json0Op[] = [
+        { p: ["itinerary", "journal", "stops", index], ld: stop },
+      ];
+      await submit(ops);
+      if (entry.snapshot.itinerary.journal?.stops?.some((item) => item.id === stopId)) {
+        throw new WanderlogError("Removed journal stop is still present", "stale_target");
+      }
+      return { stop, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
 
     return {
       content: [
-        { type: "text", text: `Removed journal stop ${formatStop(stop)} from "${trip.title}".` },
+        {
+          type: "text",
+          text: `Removed journal stop ${formatStop(result.stop)} from "${result.tripTitle}".`,
+        },
       ],
     };
   } catch (err) {

--- a/src/tools/remove-note.ts
+++ b/src/tools/remove-note.ts
@@ -93,41 +93,44 @@ export async function removeNote(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const matches = findNoteMatches(trip, args.text, args.day);
-
-    if (matches.length === 0) {
-      throw new WanderlogNotFoundError("Note", args.text);
-    }
-
-    if (matches.length > 1) {
-      const lines = matches
-        .slice(0, 5)
-        .map((m, i) => `  ${i + 1}. "${notePreview(m.plainText)}"`)
-        .join("\n");
-      const suffix = matches.length > 5 ? `\n  (${matches.length - 5} more…)` : "";
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.text}" matches ${matches.length} notes:\n${lines}${suffix}\n\nCall again with a more specific substring to identify the one you want.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const matches = findNoteMatches(trip, args.text, args.day);
+      if (matches.length === 0) {
+        throw new WanderlogNotFoundError("Note", args.text);
+      }
+      if (matches.length > 1) {
+        const lines = matches
+          .slice(0, 5)
+          .map((m, i) => `  ${i + 1}. "${notePreview(m.plainText)}"`)
+          .join("\n");
+        const suffix = matches.length > 5 ? `\n  (${matches.length - 5} more…)` : "";
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.text}" matches ${matches.length} notes:\n${lines}${suffix}\n\nCall again with a more specific substring to identify the one you want.`,
+              },
+            ],
+            isError: true,
           },
-        ],
-        isError: true,
-      };
-    }
-
-    const { sectionIndex, blockIndex, block, plainText } = matches[0]!;
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex],
-        ld: block,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const text = `Removed note "${notePreview(plainText)}" from "${trip.title}".`;
+        };
+      }
+      const { sectionIndex, blockIndex, block, plainText } = matches[0]!;
+      const blockId = block.id;
+      const ops: Json0Op[] = [
+        { p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex], ld: block },
+      ];
+      await submit(ops);
+      const remains = entry.snapshot.itinerary.sections.some((section) =>
+        section.blocks.some((candidate) => candidate.id === blockId),
+      );
+      if (remains) throw new WanderlogError("Removed note is still present", "stale_target");
+      return { plainText, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
+    const text = `Removed note "${notePreview(result.plainText)}" from "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/remove-place.ts
+++ b/src/tools/remove-place.ts
@@ -42,56 +42,59 @@ export async function removePlace(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const result = resolvePlaceRef(trip, args.place_ref);
-
-    if (result.kind === "none") {
-      throw new WanderlogNotFoundError("Place", args.place_ref);
-    }
-
-    if (result.kind === "ambiguous") {
-      const lines = result.candidates
-        .slice(0, 10)
-        .map((c, i) => {
-          const name = isPlaceBlock(c.block)
-            ? c.block.place.name
-            : `${c.block.type} block`;
-          const where = formatLocation(c.section);
-          const ordinal = ordinalLabel(i + 1);
-          return `  ${i + 1}. ${name} — ${where} (${ordinal})`;
-        })
-        .join("\n");
-
-      const firstCandidateName = isPlaceBlock(result.candidates[0]!.block)
-        ? result.candidates[0]!.block.place.name
-        : "the block";
-      const retryHint = `Call this tool again with an ordinal to pick one, e.g. place_ref: "1st ${firstCandidateName}" or "last ${firstCandidateName}". You can also combine with a day filter, e.g. "2nd ${firstCandidateName} on day 2".`;
-
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${args.place_ref}" matches ${result.candidates.length} places:\n${lines}\n\n${retryHint}`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const resolved = resolvePlaceRef(trip, args.place_ref);
+      if (resolved.kind === "none") {
+        throw new WanderlogNotFoundError("Place", args.place_ref);
+      }
+      if (resolved.kind === "ambiguous") {
+        const lines = resolved.candidates
+          .slice(0, 10)
+          .map((candidate, index) => {
+            const name = isPlaceBlock(candidate.block)
+              ? candidate.block.place.name
+              : `${candidate.block.type} block`;
+            return `  ${index + 1}. ${name} — ${formatLocation(candidate.section)} (${ordinalLabel(index + 1)})`;
+          })
+          .join("\n");
+        const firstCandidateName = isPlaceBlock(resolved.candidates[0]!.block)
+          ? resolved.candidates[0]!.block.place.name
+          : "the block";
+        const retryHint = `Call this tool again with an ordinal to pick one, e.g. place_ref: "1st ${firstCandidateName}" or "last ${firstCandidateName}". You can also combine with a day filter, e.g. "2nd ${firstCandidateName} on day 2".`;
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${args.place_ref}" matches ${resolved.candidates.length} places:\n${lines}\n\n${retryHint}`,
+              },
+            ],
+            isError: true,
           },
-        ],
-        isError: true,
+        };
+      }
+      const { sectionIndex, blockIndex, block, section } = resolved.match;
+      const blockId = block.id;
+      const ops: Json0Op[] = [
+        {
+          p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex],
+          ld: block,
+        },
+      ];
+      await submit(ops);
+      const remains = entry.snapshot.itinerary.sections.some((candidateSection) =>
+        candidateSection.blocks.some((candidate) => candidate.id === blockId),
+      );
+      if (remains) throw new WanderlogError("Removed block is still present", "stale_target");
+      return {
+        removedName: isPlaceBlock(block) ? block.place.name : `${block.type} block`,
+        location: formatLocation(section),
+        tripTitle: trip.title,
       };
-    }
-
-    const { sectionIndex, blockIndex, block, section } = result.match;
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "sections", sectionIndex, "blocks", blockIndex],
-        ld: block,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const removedName = isPlaceBlock(block)
-      ? block.place.name
-      : `${block.type} block`;
-    const text = `Removed ${removedName} from ${formatLocation(section)} in "${trip.title}".`;
+    });
+    if ("response" in result && result.response) return result.response;
+    const text = `Removed ${result.removedName} from ${result.location} in "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/rename-day.ts
+++ b/src/tools/rename-day.ts
@@ -40,42 +40,42 @@ export async function renameDay(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    const daySection = resolveDay(trip, args.day);
-    const found = findDaySectionByDate(trip, daySection.date!);
-    if (!found) {
-      throw new WanderlogValidationError(`Day ${args.day} not found in trip`);
-    }
-
-    const oldHeading = found.section.heading;
     const newHeading = args.heading;
-
-    if (oldHeading === newHeading) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Day ${daySection.date} heading is already "${newHeading}" — no change made.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const daySection = resolveDay(trip, args.day);
+      const found = findDaySectionByDate(trip, daySection.date!);
+      if (!found) {
+        throw new WanderlogValidationError(`Day ${args.day} not found in trip`);
+      }
+      const oldHeading = found.section.heading;
+      if (oldHeading === newHeading) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `Day ${daySection.date} heading is already "${newHeading}" — no change made.`,
+              },
+            ],
           },
-        ],
-      };
-    }
+        };
+      }
+      const ops: Json0Op[] = [
+        {
+          p: ["itinerary", "sections", found.index, "heading"],
+          od: oldHeading,
+          oi: newHeading,
+        },
+      ];
+      await submit(ops);
+      return { date: daySection.date, oldHeading, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
 
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "sections", found.index, "heading"],
-        od: oldHeading,
-        oi: newHeading,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const oldLabel = oldHeading || "(auto-generated)";
+    const oldLabel = result.oldHeading || "(auto-generated)";
     const newLabel = newHeading || "(auto-generated)";
-    const text = `Renamed day ${daySection.date} in "${trip.title}": "${oldLabel}" → "${newLabel}"`;
+    const text = `Renamed day ${result.date} in "${result.tripTitle}": "${oldLabel}" → "${newLabel}"`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -1,4 +1,5 @@
 import type { AppContext } from "../context.js";
+import type { CacheEntry } from "../cache/trip-cache.js";
 import { WanderlogError, WanderlogValidationError } from "../errors.js";
 import type { Json0Op } from "../ot/apply.js";
 import { resolveDay } from "../resolvers/day.js";
@@ -40,39 +41,44 @@ async function withSubmitLock<T>(
 }
 
 /**
- * Submit a JSON0 op array to the server and apply it to the live cache on
- * success. Encapsulates the version handshake so tools don't touch
- * ShareDBClient directly.
+ * Run a mutation transaction against a fresh cache entry while holding the
+ * per-trip lock. The callback resolves targets and constructs paths from the
+ * locked snapshot, then uses `submit` for one or more batches.
  *
  * Rules:
- * - Trip must already be in the cache (caller should have called tripCache.get()).
  * - Per-trip mutex: concurrent calls on the same trip serialize automatically.
- * - Op fails atomically: if submit rejects, the cache is invalidated so the
- *   next read refetches a fresh snapshot from the server.
- * - On success, cache.applyLocalOp() is called with the server-accepted version.
+ * - Each successful batch is applied to the stable entry before `submit` returns.
+ * - Only submit/apply failures invalidate the cache; callback errors do not.
  */
-export async function submitOp(
+export async function submitOp<T>(
   ctx: AppContext,
   tripKey: string,
-  ops: Json0Op[],
-): Promise<void> {
+  mutate: (
+    entry: CacheEntry,
+    submit: (ops: Json0Op[]) => Promise<void>,
+  ) => Promise<T> | T,
+): Promise<T> {
   return withSubmitLock(tripKey, async () => {
+    const entry = await ctx.tripCache.getEntry(tripKey);
     const client = ctx.pool.get(tripKey);
     if (!client.isSubscribed) {
       throw new WanderlogError(
-        `Trip ${tripKey} is not subscribed — call tripCache.get() first`,
+        `Trip ${tripKey} is not subscribed`,
         "not_subscribed",
       );
     }
-    try {
-      await submitWithRateLimitRetry(client, ops);
-      ctx.tripCache.applyLocalOp(tripKey, ops, client.version);
-    } catch (err) {
-      // Any submit failure leaves our cached view possibly inconsistent with
-      // the server. Invalidate so the next get() refetches + resubscribes.
-      ctx.tripCache.invalidate(tripKey);
-      throw err;
-    }
+
+    const submit = async (ops: Json0Op[]): Promise<void> => {
+      try {
+        await submitWithRateLimitRetry(client, ops);
+        ctx.tripCache.applyLocalOp(tripKey, ops, client.version);
+      } catch (err) {
+        ctx.tripCache.invalidate(tripKey);
+        throw err;
+      }
+    };
+
+    return mutate(entry, submit);
   });
 }
 
@@ -150,6 +156,41 @@ export function findSectionByRef(
     }
   }
   return null;
+}
+
+export function findBlockById(
+  trip: TripPlan,
+  blockId: number,
+): { sectionIndex: number; blockIndex: number; section: Section; block: Block } | null {
+  for (let sectionIndex = 0; sectionIndex < trip.itinerary.sections.length; sectionIndex++) {
+    const section = trip.itinerary.sections[sectionIndex]!;
+    const blockIndex = section.blocks.findIndex((block) => block.id === blockId);
+    if (blockIndex >= 0) {
+      return {
+        sectionIndex,
+        blockIndex,
+        section,
+        block: section.blocks[blockIndex]!,
+      };
+    }
+  }
+  return null;
+}
+
+export function assertBlockAtPath(
+  trip: TripPlan,
+  sectionIndex: number,
+  blockIndex: number,
+  blockId: number,
+): Block {
+  const block = trip.itinerary.sections[sectionIndex]?.blocks[blockIndex];
+  if (!block || block.id !== blockId) {
+    throw new WanderlogError(
+      `Block ${blockId} moved while preparing the mutation`,
+      "stale_target",
+    );
+  }
+  return block;
 }
 
 export function requireUserId(ctx: AppContext): number {

--- a/src/tools/update-section.ts
+++ b/src/tools/update-section.ts
@@ -49,63 +49,59 @@ export async function updateSection(
   args: Args,
 ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
   try {
-    const entry = await ctx.tripCache.getEntry(args.trip_key);
-    const trip = entry.snapshot;
-
-    const found = findSectionByRef(trip, args.section);
-    if (!found) {
-      throw new WanderlogValidationError(
-        `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
-      );
-    }
-
-    const { index, section } = found;
-
-    if (section.mode === "dayPlan") {
-      throw new WanderlogValidationError(
-        `Day sections cannot be renamed here. Use wanderlog_rename_day to change a day's heading instead.`,
-      );
-    }
-
-    if (findPlacesToVisitSection(trip)?.index === index) {
-      throw new WanderlogValidationError(
-        `The "Places to visit" section cannot be renamed — it is the trip's default place list. Use wanderlog_get_trip to see your custom sections.`,
-      );
-    }
-
-    if (SYSTEM_SECTION_TYPES.has(section.type)) {
-      throw new WanderlogValidationError(
-        `The "${section.heading || section.type}" section is a system section and cannot be renamed. Use wanderlog_get_trip to see your custom sections.`,
-      );
-    }
-
-    const oldHeading = found.section.heading;
     const newHeading = args.heading;
-
-    if (oldHeading === newHeading) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `Section heading is already "${newHeading || "(untitled)"}" — no change made.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const found = findSectionByRef(trip, args.section);
+      if (!found) {
+        throw new WanderlogValidationError(
+          `Section "${args.section}" not found in trip "${trip.title}". Use wanderlog_get_trip to see available sections.`,
+        );
+      }
+      const { index, section } = found;
+      if (section.mode === "dayPlan") {
+        throw new WanderlogValidationError(
+          `Day sections cannot be renamed here. Use wanderlog_rename_day to change a day's heading instead.`,
+        );
+      }
+      if (findPlacesToVisitSection(trip)?.index === index) {
+        throw new WanderlogValidationError(
+          `The "Places to visit" section cannot be renamed — it is the trip's default place list. Use wanderlog_get_trip to see your custom sections.`,
+        );
+      }
+      if (SYSTEM_SECTION_TYPES.has(section.type)) {
+        throw new WanderlogValidationError(
+          `The "${section.heading || section.type}" section is a system section and cannot be renamed. Use wanderlog_get_trip to see your custom sections.`,
+        );
+      }
+      const oldHeading = section.heading;
+      if (oldHeading === newHeading) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `Section heading is already "${newHeading || "(untitled)"}" — no change made.`,
+              },
+            ],
           },
-        ],
-      };
-    }
+        };
+      }
+      const ops: Json0Op[] = [
+        {
+          p: ["itinerary", "sections", index, "heading"],
+          od: oldHeading,
+          oi: newHeading,
+        },
+      ];
+      await submit(ops);
+      return { oldHeading, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
 
-    const ops: Json0Op[] = [
-      {
-        p: ["itinerary", "sections", found.index, "heading"],
-        od: oldHeading,
-        oi: newHeading,
-      },
-    ];
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const oldLabel = oldHeading || "(untitled)";
+    const oldLabel = result.oldHeading || "(untitled)";
     const newLabel = newHeading || "(untitled)";
-    const text = `Renamed section "${oldLabel}" → "${newLabel}" in "${trip.title}".`;
+    const text = `Renamed section "${oldLabel}" → "${newLabel}" in "${result.tripTitle}".`;
     return { content: [{ type: "text", text }] };
   } catch (err) {
     const msg =

--- a/src/tools/update-trip-dates.ts
+++ b/src/tools/update-trip-dates.ts
@@ -260,35 +260,53 @@ export async function updateTripDates(
       );
     }
     validateDateRange(args.start_date, args.end_date);
-    const trip = await ctx.tripCache.get(args.trip_key);
-    const ops = buildUpdateDatesOps(
-      trip,
-      args.start_date,
-      args.end_date,
-      args.force ?? false,
-    );
-
-    if (ops.length === 0) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: `"${trip.title}" already has dates ${args.start_date} → ${args.end_date}. No changes made.`,
+    const result = await submitOp(ctx, args.trip_key, async (entry, submit) => {
+      const trip = entry.snapshot;
+      const ops = buildUpdateDatesOps(
+        trip,
+        args.start_date,
+        args.end_date,
+        args.force ?? false,
+      );
+      if (ops.length === 0) {
+        return {
+          response: {
+            content: [
+              {
+                type: "text" as const,
+                text: `"${trip.title}" already has dates ${args.start_date} → ${args.end_date}. No changes made.`,
+              },
+            ],
           },
-        ],
-      };
+        };
+      }
+      const diff = diffDays(trip, args.start_date, args.end_date);
+      const removedSectionIds = new Set(
+        diff.toRemove.map(({ section }) => section.id),
+      );
+      await submit(ops);
+      if (
+        entry.snapshot.itinerary.sections.some((section) =>
+          removedSectionIds.has(section.id),
+        )
+      ) {
+        throw new WanderlogError(
+          "A removed day section is still present",
+          "stale_target",
+        );
+      }
+      return { diff, tripTitle: trip.title };
+    });
+    if ("response" in result && result.response) return result.response;
+    const summary: string[] = [
+      `Updated "${result.tripTitle}" to ${args.start_date} → ${args.end_date}.`,
+    ];
+    if (result.diff.toAdd.length > 0) {
+      summary.push(`  Added ${result.diff.toAdd.length} day(s): ${result.diff.toAdd.join(", ")}`);
     }
-
-    await submitOp(ctx, args.trip_key, ops);
-
-    const diff = diffDays(trip, args.start_date, args.end_date);
-    const summary: string[] = [`Updated "${trip.title}" to ${args.start_date} → ${args.end_date}.`];
-    if (diff.toAdd.length > 0) {
-      summary.push(`  Added ${diff.toAdd.length} day(s): ${diff.toAdd.join(", ")}`);
-    }
-    if (diff.toRemove.length > 0) {
+    if (result.diff.toRemove.length > 0) {
       summary.push(
-        `  Removed ${diff.toRemove.length} day(s): ${diff.toRemove.map((r) => r.date).join(", ")}`,
+        `  Removed ${result.diff.toRemove.length} day(s): ${result.diff.toRemove.map((r) => r.date).join(", ")}`,
       );
     }
     return { content: [{ type: "text", text: summary.join("\n") }] };

--- a/tests/integration/parallel-safety.test.ts
+++ b/tests/integration/parallel-safety.test.ts
@@ -1,7 +1,10 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createContext, type AppContext } from "../../src/context.ts";
+import { annotatePlace } from "../../src/tools/annotate-place.ts";
 import { addPlace } from "../../src/tools/add-place.ts";
 import { createTrip } from "../../src/tools/create-trip.ts";
+import { removePlace } from "../../src/tools/remove-place.ts";
+import { isPlaceBlock } from "../../src/types.ts";
 
 /**
  * Isolated live test for the per-trip submit mutex introduced to fix the
@@ -90,5 +93,66 @@ describe("Parallel write safety (live)", () => {
     // Total = 5 blocks across 5 days, no duplicates on any day
     const total = counts.reduce((a, b) => a + b, 0);
     expect(total).toBe(5);
+  }, 90_000);
+
+  it("keeps an annotation attached to its place while a preceding removal shifts the list", async () => {
+    const before = await ctx.rest.getTrip(tripKey!);
+    const dayOne = before.itinerary.sections.find(
+      (section) => section.mode === "dayPlan" && section.date === "2099-06-01",
+    )!;
+    const removed = dayOne.blocks.find(isPlaceBlock)!;
+    const existingIds = new Set(dayOne.blocks.map((block) => block.id));
+
+    const added = await addPlace(ctx, {
+      trip_key: tripKey!,
+      place: "Belém Tower",
+      day: "day 1",
+    });
+    if (added.isError) throw new Error(added.content[0]!.text);
+
+    const afterAdd = await ctx.rest.getTrip(tripKey!);
+    const updatedDayOne = afterAdd.itinerary.sections.find(
+      (section) => section.mode === "dayPlan" && section.date === "2099-06-01",
+    )!;
+    const target = updatedDayOne.blocks.find(
+      (block) => !existingIds.has(block.id) && isPlaceBlock(block),
+    );
+    expect(target && isPlaceBlock(target)).toBe(true);
+    if (!target || !isPlaceBlock(target)) throw new Error("new place block not found");
+
+    const note = `PARALLEL_IDENTITY_${Date.now()}`;
+    const [removeResult, annotateResult] = await Promise.all([
+      removePlace(ctx, {
+        trip_key: tripKey!,
+        place_ref: removed.place.name,
+      }),
+      annotatePlace(ctx, {
+        trip_key: tripKey!,
+        place: target.place.name,
+        note,
+        start_time: "14:15",
+        end_time: "15:30",
+      }),
+    ]);
+    if (removeResult.isError) throw new Error(removeResult.content[0]!.text);
+    if (annotateResult.isError) throw new Error(annotateResult.content[0]!.text);
+
+    const finalTrip = await ctx.rest.getTrip(tripKey!);
+    const finalBlocks = finalTrip.itinerary.sections.flatMap(
+      (section) => section.blocks,
+    );
+    expect(finalBlocks.some((block) => block.id === removed.id)).toBe(false);
+    const finalTarget = finalBlocks.find((block) => block.id === target.id);
+    expect(finalTarget && isPlaceBlock(finalTarget)).toBe(true);
+    if (!finalTarget || !isPlaceBlock(finalTarget)) {
+      throw new Error("annotated place block not found");
+    }
+    expect(finalTarget.startTime).toBe("14:15");
+    expect(finalTarget.endTime).toBe("15:30");
+    expect(
+      finalTarget.text?.ops
+        .map((op) => (typeof op.insert === "string" ? op.insert : ""))
+        .join(""),
+    ).toContain(note);
   }, 90_000);
 });

--- a/tests/unit/add-expense.test.ts
+++ b/tests/unit/add-expense.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { AppContext } from "../../src/context.ts";
-import type { Json0Op } from "../../src/ot/apply.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
 import type { TripPlan } from "../../src/types.ts";
 import { addExpense } from "../../src/tools/add-expense.ts";
 import { budgetTrip } from "../fixtures/budget-trip.ts";
 
 function makeFakeContext(trip: TripPlan): { ctx: AppContext; submittedOps: Json0Op[][] } {
   const submittedOps: Json0Op[][] = [];
+  const entry = { snapshot: structuredClone(trip), version: 1, geos: [] };
   const ctx = {
     userId: 555,
     pool: {
@@ -19,9 +20,12 @@ function makeFakeContext(trip: TripPlan): { ctx: AppContext; submittedOps: Json0
       }),
     },
     tripCache: {
-      getEntry: async () => ({ snapshot: structuredClone(trip), version: 1, geos: [] }),
-      get: async () => structuredClone(trip),
-      applyLocalOp: () => {},
+      getEntry: async () => entry,
+      get: async () => entry.snapshot,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {},
     },
   } as unknown as AppContext;

--- a/tests/unit/add-note.test.ts
+++ b/tests/unit/add-note.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AppContext } from "../../src/context.ts";
-import type { Json0Op } from "../../src/ot/apply.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
 import {
   addNote,
   addNoteInputSchema,
@@ -13,6 +13,7 @@ function makeFakeContext(trip: TripPlan): {
   submittedOps: Json0Op[][];
 } {
   const submittedOps: Json0Op[][] = [];
+  const entry = { snapshot: structuredClone(trip), version: 1, geos: [] };
   const ctx = {
     userId: 3656632,
     pool: {
@@ -25,8 +26,11 @@ function makeFakeContext(trip: TripPlan): {
       }),
     },
     tripCache: {
-      getEntry: async () => ({ snapshot: structuredClone(trip) }),
-      applyLocalOp: () => {},
+      getEntry: async () => entry,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {},
     },
   } as unknown as AppContext;

--- a/tests/unit/add-update-section.test.ts
+++ b/tests/unit/add-update-section.test.ts
@@ -18,6 +18,7 @@ function makeFakeContext(trip: TripPlan): {
   submittedOps: Json0Op[][];
 } {
   const submittedOps: Json0Op[][] = [];
+  const entry = { snapshot: structuredClone(trip), version: 1, geos: [] };
   const ctx = {
     pool: {
       get: () => ({
@@ -29,8 +30,11 @@ function makeFakeContext(trip: TripPlan): {
       }),
     },
     tripCache: {
-      getEntry: async () => ({ snapshot: structuredClone(trip) }),
-      applyLocalOp: () => {},
+      getEntry: async () => entry,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {},
     },
   } as unknown as AppContext;

--- a/tests/unit/edit-note.test.ts
+++ b/tests/unit/edit-note.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AppContext } from "../../src/context.ts";
-import type { Json0Op } from "../../src/ot/apply.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
 import type { TripPlan } from "../../src/types.ts";
 import {
   editNote,
@@ -20,6 +20,7 @@ function makeFakeContext(trip: TripPlan): {
 } {
   const submittedOps: Json0Op[][] = [];
   const invalidateCount = { value: 0 };
+  const entry = { snapshot: structuredClone(trip), version: 1, geos: [] };
 
   const ctx = {
     pool: {
@@ -32,8 +33,12 @@ function makeFakeContext(trip: TripPlan): {
       }),
     },
     tripCache: {
-      get: async () => structuredClone(trip),
-      applyLocalOp: () => {},
+      get: async () => entry.snapshot,
+      getEntry: async () => entry,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {
         invalidateCount.value++;
       },

--- a/tests/unit/expenses.test.ts
+++ b/tests/unit/expenses.test.ts
@@ -23,6 +23,7 @@ function makeFakeContext(trip: TripPlan): {
 } {
   const submittedOps: Json0Op[][] = [];
   const invalidateCount = { value: 0 };
+  const entry = { snapshot: structuredClone(trip), version: 1, geos: [] };
 
   const ctx = {
     pool: {
@@ -35,8 +36,12 @@ function makeFakeContext(trip: TripPlan): {
       }),
     },
     tripCache: {
-      get: async () => structuredClone(trip),
-      applyLocalOp: () => {},
+      get: async () => entry.snapshot,
+      getEntry: async () => entry,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {
         invalidateCount.value++;
       },

--- a/tests/unit/journal.test.ts
+++ b/tests/unit/journal.test.ts
@@ -27,6 +27,11 @@ function makeFakeContext(
   rest: RestMock = {},
 ): { ctx: AppContext; submittedOps: Json0Op[][] } {
   const submittedOps: Json0Op[][] = [];
+  const entry = {
+    snapshot: structuredClone(trip),
+    version: 1,
+    geos: [{ id: 1, name: "Fukuoka", latitude: 33.59, longitude: 130.4 }],
+  };
   const ctx = {
     userId: 555,
     rest: {
@@ -44,13 +49,12 @@ function makeFakeContext(
       }),
     },
     tripCache: {
-      get: async () => structuredClone(trip),
-      getEntry: async () => ({
-        snapshot: structuredClone(trip),
-        version: 1,
-        geos: [{ id: 1, name: "Fukuoka", latitude: 33.59, longitude: 130.4 }],
-      }),
-      applyLocalOp: () => {},
+      get: async () => entry.snapshot,
+      getEntry: async () => entry,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {},
     },
   } as unknown as AppContext;
@@ -160,6 +164,20 @@ describe("addJournal", () => {
     expect(op.li.dateTime).toBe("2026-05-31T09:00+09:00"); // offset reused from existing stops
     expect(op.li.media).toEqual([]);
     expect(op.li.text).toEqual({ ops: [{ insert: "Cherry blossoms by the lake." }] });
+  });
+
+  it("reuses an existing place without searching when allow_new_place is set", async () => {
+    const { ctx, submittedOps } = makeFakeContext(journalTrip, noSearch);
+    const res = await addJournal(ctx, {
+      trip_key: "journaltripkey",
+      place: "Ohori",
+      allow_new_place: true,
+    });
+
+    expect(res.isError).toBeUndefined();
+    expect(submittedOps).toHaveLength(1);
+    const op = submittedOps[0]![0] as { li: { place: { place_id: string } } };
+    expect(op.li.place.place_id).toBe("ChIJohori");
   });
 
   it("defaults the date to the place's itinerary day when reused", async () => {

--- a/tests/unit/mutation-identity.test.ts
+++ b/tests/unit/mutation-identity.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import { addPlace } from "../../src/tools/add-place.ts";
+import { annotatePlace } from "../../src/tools/annotate-place.ts";
+import { removePlace } from "../../src/tools/remove-place.ts";
+import type { TripPlan } from "../../src/types.ts";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("concurrent mutation identity", () => {
+  it("re-resolves an annotation by block ID after a preceding removal shifts its index", async () => {
+    const target = {
+      id: 202,
+      type: "place" as const,
+      place: { name: "Target Museum", place_id: "target" },
+      text: { ops: [{ insert: "\n" }] },
+    };
+    const decoy = {
+      id: 303,
+      type: "place" as const,
+      place: { name: "Decoy Cafe", place_id: "decoy" },
+      text: { ops: [{ insert: "untouched\n" }] },
+    };
+    const trip = {
+      title: "Identity trip",
+      itinerary: {
+        sections: [
+          {
+            id: 10,
+            type: "transit",
+            mode: "placeList",
+            heading: "Transit",
+            date: null,
+            blocks: [
+              { id: 101, type: "train", text: { ops: [{ insert: "\n" }] } },
+              target,
+              decoy,
+            ],
+          },
+        ],
+      },
+    } as unknown as TripPlan;
+    const entry = { snapshot: trip, version: 1, geos: [] };
+    const removalStarted = deferred();
+    const releaseRemoval = deferred();
+    const submitted: Json0Op[][] = [];
+    let submitCount = 0;
+    const client = {
+      isSubscribed: true,
+      version: 1,
+      async submit(ops: Json0Op[]) {
+        submitted.push(ops);
+        submitCount++;
+        if (submitCount === 1) {
+          removalStarted.resolve();
+          await releaseRemoval.promise;
+        }
+        this.version++;
+      },
+    };
+    const ctx = {
+      pool: { get: () => client },
+      tripCache: {
+        getEntry: async () => entry,
+        applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+          entry.snapshot = applyOp(entry.snapshot, ops);
+          entry.version = version;
+        },
+        invalidate: () => {},
+      },
+    } as unknown as AppContext;
+
+    const removal = removePlace(ctx, { trip_key: "trip", place_ref: "the train" });
+    await removalStarted.promise;
+    const annotation = annotatePlace(ctx, {
+      trip_key: "trip",
+      place: "Target Museum",
+      note: "Follow the target",
+    });
+    expect(submitted).toHaveLength(1);
+    releaseRemoval.resolve();
+
+    const [removeResult, annotateResult] = await Promise.all([removal, annotation]);
+    expect(removeResult.isError).toBeUndefined();
+    expect(annotateResult.isError).toBeUndefined();
+    expect(submitted[1]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      0,
+      "blocks",
+      0,
+      "text",
+    ]);
+
+    const blocks = entry.snapshot.itinerary.sections[0]!.blocks;
+    expect(blocks.map((block) => block.id)).toEqual([target.id, decoy.id]);
+    expect(blocks[0]!.text?.ops[0]!.insert).toContain("Follow the target");
+    expect(blocks[1]!.text?.ops[0]!.insert).toBe("untouched\n");
+  });
+
+  it("re-finds a newly inserted place before a follow-up rich-text batch", async () => {
+    const trip = {
+      title: "Multi-batch trip",
+      itinerary: {
+        sections: [
+          {
+            id: 10,
+            type: "normal",
+            mode: "placeList",
+            heading: "Places to visit",
+            date: null,
+            blocks: [],
+          },
+        ],
+      },
+    } as unknown as TripPlan;
+    const entry = {
+      snapshot: trip,
+      version: 1,
+      geos: [{ id: 1, name: "Test", latitude: 1, longitude: 2 }],
+    };
+    const submitted: Json0Op[][] = [];
+    let appliedBatches = 0;
+    const client = {
+      isSubscribed: true,
+      version: 1,
+      async submit(ops: Json0Op[]) {
+        submitted.push(ops);
+        this.version++;
+      },
+    };
+    const ctx = {
+      userId: 55,
+      rest: {
+        searchPlacesAutocomplete: async () => [
+          { place_id: "inserted", description: "Inserted Place" },
+        ],
+        getPlaceDetails: async () => ({
+          name: "Inserted Place",
+          place_id: "inserted",
+        }),
+        getPlacePhotos: async () => [],
+      },
+      pool: { get: () => client },
+      tripCache: {
+        getEntry: async () => entry,
+        applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+          entry.snapshot = applyOp(entry.snapshot, ops);
+          entry.version = version;
+          appliedBatches++;
+          if (appliedBatches === 1) {
+            entry.snapshot.itinerary.sections[0]!.blocks.unshift({
+              id: 404,
+              type: "note",
+              text: { ops: [{ insert: "shift\n" }] },
+            });
+          }
+        },
+        invalidate: () => {},
+      },
+    } as unknown as AppContext;
+
+    const result = await addPlace(ctx, {
+      trip_key: "trip",
+      place: "Inserted Place",
+      note: "Attached to inserted ID",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(submitted).toHaveLength(2);
+    expect(submitted[1]![0]!.p).toEqual([
+      "itinerary",
+      "sections",
+      0,
+      "blocks",
+      1,
+      "text",
+    ]);
+    const blocks = entry.snapshot.itinerary.sections[0]!.blocks;
+    expect(blocks[0]!.id).toBe(404);
+    expect(blocks[0]!.text?.ops[0]!.insert).toBe("shift\n");
+    expect(blocks[1]!.type).toBe("place");
+    expect(blocks[1]!.text?.ops[0]!.insert).toContain("Attached to inserted ID");
+  });
+});

--- a/tests/unit/rate-limit-retry.test.ts
+++ b/tests/unit/rate-limit-retry.test.ts
@@ -26,10 +26,16 @@ function makeFakeContext(failures: Array<Error | null>): {
       this.version += 1;
     },
   };
+  const entry = {
+    snapshot: {} as never,
+    version: 0,
+    geos: [],
+  };
 
   const ctx = {
     pool: { get: () => fakeClient },
     tripCache: {
+      getEntry: async () => entry,
       applyLocalOp: () => {
         applyLocalOpCount++;
       },
@@ -63,7 +69,7 @@ describe("submitOp rate-limit retry", () => {
 
   it("retries after a rate_limited error and succeeds", async () => {
     const fake = makeFakeContext([rateLimitError(), null]);
-    const promise = submitOp(fake.ctx, "tripA", ops);
+    const promise = submitOp(fake.ctx, "tripA", (_entry, submit) => submit(ops));
     await vi.advanceTimersByTimeAsync(2_000);
     await promise;
     expect(fake.submitCalls()).toBe(2);
@@ -78,7 +84,7 @@ describe("submitOp rate-limit retry", () => {
       rateLimitError(),
       rateLimitError(),
     ]);
-    const promise = submitOp(fake.ctx, "tripA", ops);
+    const promise = submitOp(fake.ctx, "tripA", (_entry, submit) => submit(ops));
     const assertion = expect(promise).rejects.toMatchObject({
       code: "rate_limited",
     });
@@ -93,7 +99,9 @@ describe("submitOp rate-limit retry", () => {
     const fake = makeFakeContext([
       new WanderlogError("Submit op timeout", "submit_timeout"),
     ]);
-    await expect(submitOp(fake.ctx, "tripA", ops)).rejects.toMatchObject({
+    await expect(
+      submitOp(fake.ctx, "tripA", (_entry, submit) => submit(ops)),
+    ).rejects.toMatchObject({
       code: "submit_timeout",
     });
     expect(fake.submitCalls()).toBe(1);

--- a/tests/unit/remove-note.test.ts
+++ b/tests/unit/remove-note.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AppContext } from "../../src/context.ts";
-import type { Json0Op } from "../../src/ot/apply.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
 import type { TripPlan } from "../../src/types.ts";
 import {
   extractPlainText,
@@ -21,6 +21,7 @@ function makeFakeContext(trip: TripPlan): {
 } {
   const submittedOps: Json0Op[][] = [];
   const invalidateCount = { value: 0 };
+  const entry = { snapshot: structuredClone(trip), version: 1, geos: [] };
 
   const ctx = {
     pool: {
@@ -33,8 +34,12 @@ function makeFakeContext(trip: TripPlan): {
       }),
     },
     tripCache: {
-      get: async () => structuredClone(trip),
-      applyLocalOp: () => {},
+      get: async () => entry.snapshot,
+      getEntry: async () => entry,
+      applyLocalOp: (_key: string, ops: Json0Op[], version: number) => {
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
+      },
       invalidate: () => {
         invalidateCount.value++;
       },

--- a/tests/unit/submit-lock.test.ts
+++ b/tests/unit/submit-lock.test.ts
@@ -1,161 +1,197 @@
 import { describe, expect, it } from "vitest";
+import type { CacheEntry } from "../../src/cache/trip-cache.ts";
 import type { AppContext } from "../../src/context.ts";
-import type { Json0Op } from "../../src/ot/apply.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import type { TripPlan } from "../../src/types.ts";
 import { submitOp } from "../../src/tools/shared.ts";
 
-/**
- * Exercises the per-trip submit mutex in isolation. Uses a fake AppContext
- * that records the order and timing of submits against the fake ShareDBClient,
- * so we can prove parallel calls are actually serialized.
- */
+type Snapshot = TripPlan & { counter: number };
 
-type SubmitRecord = {
-  tripKey: string;
-  startedAt: number;
-  endedAt: number;
-  result: "ok" | "fail";
-};
+function makeEntry(): CacheEntry {
+  return {
+    snapshot: { counter: 0 } as Snapshot,
+    version: 0,
+    geos: [],
+  };
+}
 
 function makeFakeContext(options: {
-  submitDelay: number;
+  submitDelay?: number;
   failOn?: (callIndex: number) => boolean;
-}): {
-  ctx: AppContext;
-  records: SubmitRecord[];
-  invalidateCount: number;
-  applyLocalOpCount: number;
-} {
-  const records: SubmitRecord[] = [];
+  failApply?: boolean;
+} = {}) {
+  const entries = new Map<string, CacheEntry>();
+  const activeByTrip = new Map<string, number>();
+  let activeTotal = 0;
+  let maxActiveTotal = 0;
+  let maxActiveSameTrip = 0;
   let callIndex = 0;
   let invalidateCount = 0;
   let applyLocalOpCount = 0;
+  let getEntryCount = 0;
 
-  const fakeClient = {
-    isSubscribed: true,
-    version: 0,
-    async submit(_ops: Json0Op[]): Promise<void> {
-      const thisCall = callIndex++;
-      const rec: SubmitRecord = {
-        tripKey: "",
-        startedAt: Date.now(),
-        endedAt: 0,
-        result: "ok",
-      };
-      records.push(rec);
-      await new Promise((r) => setTimeout(r, options.submitDelay));
-      rec.endedAt = Date.now();
-      if (options.failOn?.(thisCall)) {
-        rec.result = "fail";
-        throw new Error(`simulated failure on call ${thisCall}`);
-      }
-      this.version += 1;
-    },
+  const getEntry = (tripKey: string): CacheEntry => {
+    getEntryCount++;
+    let entry = entries.get(tripKey);
+    if (!entry) {
+      entry = makeEntry();
+      entries.set(tripKey, entry);
+    }
+    return entry;
   };
 
+  const clients = new Map<string, {
+    isSubscribed: boolean;
+    version: number;
+    submit(ops: Json0Op[]): Promise<void>;
+  }>();
   const ctx = {
     pool: {
-      get: (_tripKey: string) => fakeClient,
+      get: (tripKey: string) => {
+        let client = clients.get(tripKey);
+        if (!client) {
+          client = {
+            isSubscribed: true,
+            version: 0,
+            async submit(_ops: Json0Op[]) {
+              const thisCall = callIndex++;
+              const activeForTrip = (activeByTrip.get(tripKey) ?? 0) + 1;
+              activeByTrip.set(tripKey, activeForTrip);
+              activeTotal++;
+              maxActiveSameTrip = Math.max(maxActiveSameTrip, activeForTrip);
+              maxActiveTotal = Math.max(maxActiveTotal, activeTotal);
+              await new Promise((resolve) =>
+                setTimeout(resolve, options.submitDelay ?? 5),
+              );
+              activeByTrip.set(tripKey, activeForTrip - 1);
+              activeTotal--;
+              if (options.failOn?.(thisCall)) {
+                throw new Error(`simulated failure on call ${thisCall}`);
+              }
+              this.version++;
+            },
+          };
+          clients.set(tripKey, client);
+        }
+        return client;
+      },
     },
     tripCache: {
-      applyLocalOp: (_tripKey: string, _ops: Json0Op[], _version: number) => {
+      getEntry: async (tripKey: string) => getEntry(tripKey),
+      applyLocalOp: (tripKey: string, ops: Json0Op[], version: number) => {
         applyLocalOpCount++;
+        if (options.failApply) throw new Error("simulated apply failure");
+        const entry = getEntry(tripKey);
+        entry.snapshot = applyOp(entry.snapshot, ops);
+        entry.version = version;
       },
-      invalidate: (_tripKey: string) => {
+      invalidate: (tripKey: string) => {
         invalidateCount++;
+        entries.delete(tripKey);
       },
     },
   } as unknown as AppContext;
 
   return {
     ctx,
-    records,
-    get invalidateCount() {
-      return invalidateCount;
-    },
-    get applyLocalOpCount() {
-      return applyLocalOpCount;
-    },
+    entry: (tripKey = "tripA") => getEntry(tripKey),
+    counts: () => ({
+      applyLocalOpCount,
+      getEntryCount,
+      invalidateCount,
+      maxActiveSameTrip,
+      maxActiveTotal,
+    }),
   };
 }
 
-describe("submitOp per-trip mutex", () => {
-  it("serializes parallel submits on the same trip", async () => {
-    const { ctx, records } = makeFakeContext({ submitDelay: 40 });
-    const ops: Json0Op[] = [{ p: ["a"], oi: 1 }];
+const increment = async (
+  _entry: CacheEntry,
+  submit: (ops: Json0Op[]) => Promise<void>,
+) => submit([{ p: ["counter"], na: 1 }]);
 
-    // Fire 5 submits in parallel. They should run strictly one at a time.
-    await Promise.all([
-      submitOp(ctx, "tripA", ops),
-      submitOp(ctx, "tripA", ops),
-      submitOp(ctx, "tripA", ops),
-      submitOp(ctx, "tripA", ops),
-      submitOp(ctx, "tripA", ops),
-    ]);
-
-    expect(records.length).toBe(5);
-    // Each submit starts after (or at) the previous one's end. With a 40ms
-    // delay and strict serialization, gaps are >= 0; with parallelism they'd
-    // all start near 0 and overlap heavily.
-    for (let i = 1; i < records.length; i++) {
-      expect(records[i]!.startedAt).toBeGreaterThanOrEqual(
-        records[i - 1]!.endedAt - 5,
-      );
-    }
+describe("submitOp per-trip mutation transaction", () => {
+  it("serializes same-trip mutations", async () => {
+    const fake = makeFakeContext({ submitDelay: 15 });
+    await Promise.all(
+      Array.from({ length: 5 }, () => submitOp(fake.ctx, "tripA", increment)),
+    );
+    expect(fake.counts().maxActiveSameTrip).toBe(1);
+    expect((fake.entry().snapshot as Snapshot).counter).toBe(5);
   });
 
-  it("runs submits on different trips in parallel", async () => {
-    const { ctx, records } = makeFakeContext({ submitDelay: 50 });
-    const ops: Json0Op[] = [{ p: ["a"], oi: 1 }];
-
-    const start = Date.now();
+  it("runs different-trip mutations in parallel", async () => {
+    const fake = makeFakeContext({ submitDelay: 20 });
     await Promise.all([
-      submitOp(ctx, "tripA", ops),
-      submitOp(ctx, "tripB", ops),
-      submitOp(ctx, "tripC", ops),
+      submitOp(fake.ctx, "tripA", increment),
+      submitOp(fake.ctx, "tripB", increment),
+      submitOp(fake.ctx, "tripC", increment),
     ]);
-    const elapsed = Date.now() - start;
-
-    expect(records.length).toBe(3);
-    // Parallel across trips: total time should be roughly one delay, not three.
-    expect(elapsed).toBeLessThan(120);
+    expect(fake.counts().maxActiveTotal).toBe(3);
   });
 
-  it("a failed submit does not block the queue", async () => {
-    const holder = makeFakeContext({
-      submitDelay: 20,
-      failOn: (i) => i === 0,
-    });
-    const ops: Json0Op[] = [{ p: ["a"], oi: 1 }];
-
+  it("recovers the queue after a failed submit", async () => {
+    const fake = makeFakeContext({ failOn: (index) => index === 0 });
     const results = await Promise.allSettled([
-      submitOp(holder.ctx, "tripA", ops),
-      submitOp(holder.ctx, "tripA", ops),
-      submitOp(holder.ctx, "tripA", ops),
+      submitOp(fake.ctx, "tripA", increment),
+      submitOp(fake.ctx, "tripA", increment),
+      submitOp(fake.ctx, "tripA", increment),
     ]);
-
-    expect(results[0]!.status).toBe("rejected");
-    expect(results[1]!.status).toBe("fulfilled");
-    expect(results[2]!.status).toBe("fulfilled");
+    expect(results.map((result) => result.status)).toEqual([
+      "rejected",
+      "fulfilled",
+      "fulfilled",
+    ]);
   });
 
-  it("invalidates the cache on submit failure", async () => {
-    const holder = makeFakeContext({
-      submitDelay: 10,
-      failOn: () => true,
+  it("gives queued callbacks the snapshot updated by prior mutations", async () => {
+    const fake = makeFakeContext({ submitDelay: 15 });
+    const seen: number[] = [];
+    const mutation = (entry: CacheEntry, submit: (ops: Json0Op[]) => Promise<void>) => {
+      seen.push((entry.snapshot as Snapshot).counter);
+      return submit([{ p: ["counter"], na: 1 }]);
+    };
+    await Promise.all([
+      submitOp(fake.ctx, "tripA", mutation),
+      submitOp(fake.ctx, "tripA", mutation),
+    ]);
+    expect(seen).toEqual([0, 1]);
+  });
+
+  it("applies successful batches to the stable cache entry", async () => {
+    const fake = makeFakeContext();
+    const entry = fake.entry();
+    await submitOp(fake.ctx, "tripA", increment);
+    expect(fake.entry()).toBe(entry);
+    expect((entry.snapshot as Snapshot).counter).toBe(1);
+    expect(fake.counts()).toMatchObject({
+      applyLocalOpCount: 1,
+      invalidateCount: 0,
     });
-    const ops: Json0Op[] = [{ p: ["a"], oi: 1 }];
-
-    await expect(submitOp(holder.ctx, "tripA", ops)).rejects.toThrow();
-    expect(holder.invalidateCount).toBe(1);
-    expect(holder.applyLocalOpCount).toBe(0);
   });
 
-  it("applies op locally on submit success", async () => {
-    const holder = makeFakeContext({ submitDelay: 10 });
-    const ops: Json0Op[] = [{ p: ["a"], oi: 1 }];
+  it("invalidates on submit or local-apply failure", async () => {
+    const submitFailure = makeFakeContext({ failOn: () => true });
+    await expect(
+      submitOp(submitFailure.ctx, "tripA", increment),
+    ).rejects.toThrow("simulated failure");
+    expect(submitFailure.counts().invalidateCount).toBe(1);
 
-    await submitOp(holder.ctx, "tripA", ops);
-    expect(holder.applyLocalOpCount).toBe(1);
-    expect(holder.invalidateCount).toBe(0);
+    const applyFailure = makeFakeContext({ failApply: true });
+    await expect(
+      submitOp(applyFailure.ctx, "tripA", increment),
+    ).rejects.toThrow("simulated apply failure");
+    expect(applyFailure.counts().invalidateCount).toBe(1);
+  });
+
+  it("does not invalidate on callback validation errors", async () => {
+    const fake = makeFakeContext();
+    await expect(
+      submitOp(fake.ctx, "tripA", () => {
+        throw new Error("validation failed");
+      }),
+    ).rejects.toThrow("validation failed");
+    expect(fake.counts().invalidateCount).toBe(0);
+    await expect(submitOp(fake.ctx, "tripA", increment)).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Move each trip mutation's target resolution and JSON0 path construction inside the per-trip lock, so queued writes always use the latest cached snapshot. Multi-step mutations now re-find blocks by stable IDs between submits, and remove/annotate operations verify that the intended item changed. Closes #56.

## Test plan

- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run build`
- `npm run test -- --reporter=dot` (426 tests)
- `npm run test:integration` with the Keychain-backed Wanderlog cookie and a dedicated private fixture trip (50 tests)
- Deterministic regression coverage for concurrent remove/annotate and list shifts between multi-step submits

## Agent-facing surface changes

- [x] Changed a tool description, parameter doc, or error message
      (these are prompts shipped to other agents — review for
      injection risk and clarity)
- [ ] Changed or relaxed an invariant in `docs/architecture.md`