### PR TITLE
Fix cached trip recovery after WebSocket close

### DIFF
--- a/src/cache/trip-cache.ts
+++ b/src/cache/trip-cache.ts
@@ -129,14 +129,11 @@ export class TripCache {
 
   private deleteEntry(tripKey: string): void {
     const entry = this.entries.get(tripKey);
-    if (entry) {
-      entry.client.off("remoteOp", entry.remoteOpListener);
-      entry.client.off("closed", entry.closedListener);
-      this.entries.delete(tripKey);
-      this.pool.evict(tripKey, entry.client);
-      return;
-    }
-    this.pool.evict(tripKey);
+    if (!entry) return;
+    entry.client.off("remoteOp", entry.remoteOpListener);
+    entry.client.off("closed", entry.closedListener);
+    this.entries.delete(tripKey);
+    this.pool.evict(tripKey, entry.client);
   }
 
   invalidate(tripKey: string): void {

--- a/src/cache/trip-cache.ts
+++ b/src/cache/trip-cache.ts
@@ -1,13 +1,16 @@
 import { applyOp, type Json0Op } from "../ot/apply.js";
+import { WanderlogError } from "../errors.js";
 import type { RestClient } from "../transport/rest.js";
-import type { ShareDBPool } from "../transport/sharedb.js";
+import type { ShareDBClient, ShareDBPool } from "../transport/sharedb.js";
 import type { Geo, TripPlan } from "../types.js";
 
 export type CacheEntry = {
   snapshot: TripPlan;
   version: number;
   geos: Geo[];
-  listener?: (ops: Json0Op[], version: number) => void;
+  client: ShareDBClient;
+  remoteOpListener: (ops: Json0Op[], version: number) => void;
+  closedListener: (code: number) => void;
 };
 
 /**
@@ -39,7 +42,10 @@ export class TripCache {
 
   private async ensureEntry(tripKey: string): Promise<CacheEntry> {
     const existing = this.entries.get(tripKey);
-    if (existing) return existing;
+    if (existing) {
+      if (existing.client.isSubscribed) return existing;
+      this.deleteEntry(tripKey);
+    }
 
     const pending = this.subscribing.get(tripKey);
     if (pending) return pending;
@@ -61,27 +67,53 @@ export class TripCache {
     const { geos } = await this.rest.getTripWithResources(tripKey);
 
     const client = this.pool.get(tripKey);
-    const snapshot = await client.subscribe();
+    try {
+      const snapshot = await client.subscribe();
 
-    const listener = (ops: Json0Op[], version: number) => {
-      const current = this.entries.get(tripKey);
-      if (!current) return;
-      try {
-        current.snapshot = applyOp(current.snapshot, ops);
-        current.version = version;
-      } catch {
-        // If a remote op fails to apply to our snapshot, our view is stale.
-        // Drop the entry; next get() re-subscribes from a fresh snapshot.
-        this.deleteEntry(tripKey);
+      const remoteOpListener = (ops: Json0Op[], version: number) => {
+        const current = this.entries.get(tripKey);
+        if (!current || current.client !== client) return;
+        try {
+          current.snapshot = applyOp(current.snapshot, ops);
+          current.version = version;
+        } catch {
+          this.deleteEntry(tripKey);
+        }
+      };
+      const closedListener = () => {
+        if (this.entries.get(tripKey)?.client === client) {
+          // Retiring the client suppresses background resubscription, which
+          // could otherwise refresh the client without refreshing this cache.
+          this.deleteEntry(tripKey);
+        }
+      };
+
+      client.on("remoteOp", remoteOpListener);
+      client.on("closed", closedListener);
+
+      if (!client.isSubscribed) {
+        client.off("remoteOp", remoteOpListener);
+        client.off("closed", closedListener);
+        throw new WanderlogError(
+          `Trip ${tripKey} subscription closed before it could be cached`,
+          "ws_closed",
+        );
       }
-    };
 
-    client.on("remoteOp", listener);
-
-    const entry: CacheEntry = { snapshot, version: client.version, geos, listener };
-    this.entries.set(tripKey, entry);
-
-    return entry;
+      const entry: CacheEntry = {
+        snapshot,
+        version: client.version,
+        geos,
+        client,
+        remoteOpListener,
+        closedListener,
+      };
+      this.entries.set(tripKey, entry);
+      return entry;
+    } catch (err) {
+      this.pool.evict(tripKey, client);
+      throw err;
+    }
   }
 
   /**
@@ -98,12 +130,13 @@ export class TripCache {
   private deleteEntry(tripKey: string): void {
     const entry = this.entries.get(tripKey);
     if (entry) {
-      if (entry.listener) {
-        const client = this.pool.get(tripKey);
-        client.off("remoteOp", entry.listener);
-      }
+      entry.client.off("remoteOp", entry.remoteOpListener);
+      entry.client.off("closed", entry.closedListener);
       this.entries.delete(tripKey);
+      this.pool.evict(tripKey, entry.client);
+      return;
     }
+    this.pool.evict(tripKey);
   }
 
   invalidate(tripKey: string): void {

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -61,15 +61,14 @@ export async function submitOp<T>(
   return withSubmitLock(tripKey, async () => {
     const entry = await ctx.tripCache.getEntry(tripKey);
     const client = ctx.pool.get(tripKey);
-    if (!client.isSubscribed) {
-      throw new WanderlogError(
-        `Trip ${tripKey} is not subscribed`,
-        "not_subscribed",
-      );
-    }
-
     const submit = async (ops: Json0Op[]): Promise<void> => {
       try {
+        if (!client.isSubscribed) {
+          throw new WanderlogError(
+            `Trip ${tripKey} is not subscribed`,
+            "not_subscribed",
+          );
+        }
         await submitWithRateLimitRetry(client, ops);
         ctx.tripCache.applyLocalOp(tripKey, ops, client.version);
       } catch (err) {

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -48,7 +48,8 @@ async function withSubmitLock<T>(
  * Rules:
  * - Per-trip mutex: concurrent calls on the same trip serialize automatically.
  * - Each successful batch is applied to the stable entry before `submit` returns.
- * - Only submit/apply failures invalidate the cache; callback errors do not.
+ * - Ambiguous submit failures and local apply failures invalidate the cache.
+ * - Confirmed server rejections and callback errors leave the cache intact.
  */
 export async function submitOp<T>(
   ctx: AppContext,
@@ -70,6 +71,14 @@ export async function submitOp<T>(
           );
         }
         await submitWithRateLimitRetry(client, ops);
+      } catch (err) {
+        if (!isConfirmedNonApplication(err)) {
+          ctx.tripCache.invalidate(tripKey);
+        }
+        throw err;
+      }
+
+      try {
         ctx.tripCache.applyLocalOp(tripKey, ops, client.version);
       } catch (err) {
         ctx.tripCache.invalidate(tripKey);
@@ -79,6 +88,20 @@ export async function submitOp<T>(
 
     return mutate(entry, submit);
   });
+}
+
+const CONFIRMED_NON_APPLICATION_CODES = new Set([
+  "empty_op",
+  "rate_limited",
+  "ws_not_open",
+  "ws_op_rejected",
+]);
+
+function isConfirmedNonApplication(err: unknown): boolean {
+  return (
+    err instanceof WanderlogError &&
+    CONFIRMED_NON_APPLICATION_CODES.has(err.code)
+  );
 }
 
 const RATE_LIMIT_RETRY_DELAYS_MS = [2_000, 4_000, 8_000];

--- a/src/transport/sharedb.ts
+++ b/src/transport/sharedb.ts
@@ -213,7 +213,7 @@ export class ShareDBClient extends EventEmitter {
         const pending = this.pendingOps.get(frame.seq)!;
         this.pendingOps.delete(frame.seq);
         clearTimeout(pending.timer);
-        pending.reject(new WanderlogError(errMsg, "ws_error"));
+        pending.reject(new WanderlogError(errMsg, "ws_op_rejected"));
         return;
       }
 

--- a/src/transport/sharedb.ts
+++ b/src/transport/sharedb.ts
@@ -443,6 +443,15 @@ export class ShareDBPool {
     return this.clients.has(tripKey);
   }
 
+  evict(tripKey: string, expectedClient?: ShareDBClient): boolean {
+    const client = this.clients.get(tripKey);
+    if (!client || (expectedClient && client !== expectedClient)) return false;
+
+    this.clients.delete(tripKey);
+    client.close();
+    return true;
+  }
+
   closeAll(): void {
     for (const client of this.clients.values()) {
       client.close();

--- a/tests/unit/rate-limit-retry.test.ts
+++ b/tests/unit/rate-limit-retry.test.ts
@@ -77,7 +77,7 @@ describe("submitOp rate-limit retry", () => {
     expect(fake.invalidateCount()).toBe(0);
   });
 
-  it("gives up after exhausting retries and invalidates the cache", async () => {
+  it("gives up after exhausting retries without invalidating the cache", async () => {
     const fake = makeFakeContext([
       rateLimitError(),
       rateLimitError(),
@@ -92,10 +92,22 @@ describe("submitOp rate-limit retry", () => {
     await assertion;
     expect(fake.submitCalls()).toBe(4);
     expect(fake.applyLocalOpCount()).toBe(0);
-    expect(fake.invalidateCount()).toBe(1);
+    expect(fake.invalidateCount()).toBe(0);
   });
 
-  it("does not retry non-rate-limit errors", async () => {
+  it.each(["empty_op", "ws_not_open", "ws_op_rejected"])(
+    "preserves the cache after confirmed non-application error %s",
+    async (code) => {
+      const fake = makeFakeContext([new WanderlogError("rejected", code)]);
+      await expect(
+        submitOp(fake.ctx, "tripA", (_entry, submit) => submit(ops)),
+      ).rejects.toMatchObject({ code });
+      expect(fake.submitCalls()).toBe(1);
+      expect(fake.invalidateCount()).toBe(0);
+    },
+  );
+
+  it("invalidates after an ambiguous non-rate-limit error", async () => {
     const fake = makeFakeContext([
       new WanderlogError("Submit op timeout", "submit_timeout"),
     ]);
@@ -168,6 +180,18 @@ describe("ShareDBClient bare {code, message} rejection frames", () => {
     const { client, pending } = clientWithPendingOp();
     deliverFrame(client, { code: 4999, message: "nope" });
     await expect(pending).rejects.toMatchObject({ code: "ws_rejected" });
+  });
+
+  it("maps a targeted op error to ws_op_rejected", async () => {
+    const { client, pending } = clientWithPendingOp();
+    deliverFrame(client, { error: "bad path", seq: 1 });
+    await expect(pending).rejects.toMatchObject({ code: "ws_op_rejected" });
+  });
+
+  it("keeps an unscoped op error ambiguous", async () => {
+    const { client, pending } = clientWithPendingOp();
+    deliverFrame(client, { error: "unknown failure" });
+    await expect(pending).rejects.toMatchObject({ code: "ws_error" });
   });
 
   it("does not treat op acks (which carry `a`) as rejections", async () => {

--- a/tests/unit/sharedb.test.ts
+++ b/tests/unit/sharedb.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ShareDBClient } from "../../src/transport/sharedb.ts";
+import { ShareDBClient, ShareDBPool } from "../../src/transport/sharedb.ts";
 import { WanderlogAuthError, WanderlogError } from "../../src/errors.ts";
 
 describe("ShareDBClient reconnect logic", () => {
@@ -104,5 +104,38 @@ describe("ShareDBClient reconnect logic", () => {
     
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
     expect(consoleWarnSpy.mock.calls[0]![0]).toContain("Reconnection has failed 6 times consecutively");
+  });
+});
+
+describe("ShareDBPool eviction", () => {
+  const config = {
+    wsBaseUrl: "wss://test",
+    baseUrl: "https://test",
+    userAgent: "test",
+  } as any;
+
+  it("closes and removes the current trip client", () => {
+    const pool = new ShareDBPool(config);
+    const client = pool.get("tripA");
+    const closeSpy = vi.spyOn(client, "close");
+
+    expect(pool.evict("tripA", client)).toBe(true);
+    expect(closeSpy).toHaveBeenCalledOnce();
+    expect(pool.has("tripA")).toBe(false);
+    expect(pool.get("tripA")).not.toBe(client);
+    pool.closeAll();
+  });
+
+  it("does not evict a replacement client for a stale caller", () => {
+    const pool = new ShareDBPool(config);
+    const staleClient = pool.get("tripA");
+    pool.evict("tripA", staleClient);
+    const replacement = pool.get("tripA");
+    const closeSpy = vi.spyOn(replacement, "close");
+
+    expect(pool.evict("tripA", staleClient)).toBe(false);
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(pool.get("tripA")).toBe(replacement);
+    pool.closeAll();
   });
 });

--- a/tests/unit/submit-lock.test.ts
+++ b/tests/unit/submit-lock.test.ts
@@ -7,11 +7,20 @@ import { submitOp } from "../../src/tools/shared.ts";
 
 type Snapshot = TripPlan & { counter: number };
 
-function makeEntry(): CacheEntry {
+type FakeClient = {
+  isSubscribed: boolean;
+  version: number;
+  submit(ops: Json0Op[]): Promise<void>;
+};
+
+function makeEntry(client: FakeClient): CacheEntry {
   return {
     snapshot: { counter: 0 } as Snapshot,
     version: 0,
     geos: [],
+    client: client as unknown as CacheEntry["client"],
+    remoteOpListener: () => {},
+    closedListener: () => {},
   };
 }
 
@@ -21,6 +30,7 @@ function makeFakeContext(options: {
   failApply?: boolean;
 } = {}) {
   const entries = new Map<string, CacheEntry>();
+  const clients = new Map<string, FakeClient>();
   const activeByTrip = new Map<string, number>();
   let activeTotal = 0;
   let maxActiveTotal = 0;
@@ -30,51 +40,48 @@ function makeFakeContext(options: {
   let applyLocalOpCount = 0;
   let getEntryCount = 0;
 
+  const getClient = (tripKey: string): FakeClient => {
+    let client = clients.get(tripKey);
+    if (!client) {
+      client = {
+        isSubscribed: true,
+        version: 0,
+        async submit(_ops: Json0Op[]) {
+          const thisCall = callIndex++;
+          const activeForTrip = (activeByTrip.get(tripKey) ?? 0) + 1;
+          activeByTrip.set(tripKey, activeForTrip);
+          activeTotal++;
+          maxActiveSameTrip = Math.max(maxActiveSameTrip, activeForTrip);
+          maxActiveTotal = Math.max(maxActiveTotal, activeTotal);
+          await new Promise((resolve) =>
+            setTimeout(resolve, options.submitDelay ?? 5),
+          );
+          activeByTrip.set(tripKey, activeForTrip - 1);
+          activeTotal--;
+          if (options.failOn?.(thisCall)) {
+            throw new Error(`simulated failure on call ${thisCall}`);
+          }
+          this.version++;
+        },
+      };
+      clients.set(tripKey, client);
+    }
+    return client;
+  };
+
   const getEntry = (tripKey: string): CacheEntry => {
     getEntryCount++;
     let entry = entries.get(tripKey);
     if (!entry) {
-      entry = makeEntry();
+      entry = makeEntry(getClient(tripKey));
       entries.set(tripKey, entry);
     }
     return entry;
   };
 
-  const clients = new Map<string, {
-    isSubscribed: boolean;
-    version: number;
-    submit(ops: Json0Op[]): Promise<void>;
-  }>();
   const ctx = {
     pool: {
-      get: (tripKey: string) => {
-        let client = clients.get(tripKey);
-        if (!client) {
-          client = {
-            isSubscribed: true,
-            version: 0,
-            async submit(_ops: Json0Op[]) {
-              const thisCall = callIndex++;
-              const activeForTrip = (activeByTrip.get(tripKey) ?? 0) + 1;
-              activeByTrip.set(tripKey, activeForTrip);
-              activeTotal++;
-              maxActiveSameTrip = Math.max(maxActiveSameTrip, activeForTrip);
-              maxActiveTotal = Math.max(maxActiveTotal, activeTotal);
-              await new Promise((resolve) =>
-                setTimeout(resolve, options.submitDelay ?? 5),
-              );
-              activeByTrip.set(tripKey, activeForTrip - 1);
-              activeTotal--;
-              if (options.failOn?.(thisCall)) {
-                throw new Error(`simulated failure on call ${thisCall}`);
-              }
-              this.version++;
-            },
-          };
-          clients.set(tripKey, client);
-        }
-        return client;
-      },
+      get: (tripKey: string) => getClient(tripKey),
     },
     tripCache: {
       getEntry: async (tripKey: string) => getEntry(tripKey),
@@ -88,6 +95,9 @@ function makeFakeContext(options: {
       invalidate: (tripKey: string) => {
         invalidateCount++;
         entries.delete(tripKey);
+        const client = clients.get(tripKey);
+        if (client) client.isSubscribed = false;
+        clients.delete(tripKey);
       },
     },
   } as unknown as AppContext;
@@ -147,7 +157,10 @@ describe("submitOp per-trip mutation transaction", () => {
   it("gives queued callbacks the snapshot updated by prior mutations", async () => {
     const fake = makeFakeContext({ submitDelay: 15 });
     const seen: number[] = [];
-    const mutation = (entry: CacheEntry, submit: (ops: Json0Op[]) => Promise<void>) => {
+    const mutation = (
+      entry: CacheEntry,
+      submit: (ops: Json0Op[]) => Promise<void>,
+    ) => {
       seen.push((entry.snapshot as Snapshot).counter);
       return submit([{ p: ["counter"], na: 1 }]);
     };
@@ -182,6 +195,17 @@ describe("submitOp per-trip mutation transaction", () => {
       submitOp(applyFailure.ctx, "tripA", increment),
     ).rejects.toThrow("simulated apply failure");
     expect(applyFailure.counts().invalidateCount).toBe(1);
+  });
+
+  it("invalidates when the subscription closes before submit", async () => {
+    const fake = makeFakeContext();
+    await expect(
+      submitOp(fake.ctx, "tripA", (entry, submit) => {
+        (entry.client as unknown as FakeClient).isSubscribed = false;
+        return submit([{ p: ["counter"], na: 1 }]);
+      }),
+    ).rejects.toMatchObject({ code: "not_subscribed" });
+    expect(fake.counts().invalidateCount).toBe(1);
   });
 
   it("does not invalidate on callback validation errors", async () => {

--- a/tests/unit/trip-cache.test.ts
+++ b/tests/unit/trip-cache.test.ts
@@ -115,9 +115,34 @@ describe("TripCache subscription lifecycle", () => {
     expect(pool.has("tripA")).toBe(false);
   });
 
+  it("does not evict a replacement client when invalidating an absent entry", async () => {
+    const { cache, pool } = makeCache();
+    await cache.get("tripA");
+    const firstClient = pool.created.get("tripA")![0]!;
+    firstClient.disconnect();
+    const replacementClient = pool.get("tripA");
+
+    cache.invalidate("tripA");
+
+    expect(pool.has("tripA")).toBe(true);
+    expect(replacementClient.closeCalled).toBe(0);
+  });
+
+  it("treats repeated invalidation as a no-op", async () => {
+    const { cache, pool } = makeCache();
+    await cache.get("tripA");
+    const client = pool.created.get("tripA")![0]!;
+
+    cache.invalidate("tripA");
+    cache.invalidate("tripA");
+
+    expect(client.closeCalled).toBe(1);
+    expect(pool.has("tripA")).toBe(false);
+  });
+
   it("recovers from a normal close with a fresh client and snapshot", async () => {
     const { cache, pool, getTripCalls } = makeCache();
-    const first = await cache.getEntry("tripA");
+    await cache.getEntry("tripA");
     const firstClient = pool.created.get("tripA")![0]!;
 
     firstClient.disconnect(1000);
@@ -154,33 +179,31 @@ describe("TripCache subscription lifecycle", () => {
       pool: pool as unknown as ShareDBPool,
       tripCache: cache,
     } as AppContext;
-    const first = await cache.getEntry("tripA");
-    const firstClient = pool.created.get("tripA")![0]!;
-    const staleOps: Json0Op[] = [
-      {
-        p: ["title"],
-        od: first.snapshot.title,
-        oi: "stale mutation",
-      },
-    ];
+    await expect(
+      submitOp(ctx, "tripA", (entry, submit) => {
+        const ops: Json0Op[] = [
+          {
+            p: ["title"],
+            od: entry.snapshot.title,
+            oi: "interrupted mutation",
+          },
+        ];
+        (entry.client as unknown as FakeShareDBClient).disconnect(1000);
+        return submit(ops);
+      }),
+    ).rejects.toMatchObject({ code: "not_subscribed" });
 
-    firstClient.disconnect(1000);
+    await submitOp(ctx, "tripA", (entry, submit) =>
+      submit([
+        {
+          p: ["title"],
+          od: entry.snapshot.title,
+          oi: "recovered mutation",
+        },
+      ]),
+    );
 
-    await expect(submitOp(ctx, "tripA", staleOps)).rejects.toMatchObject({
-      code: "not_subscribed",
-    });
-
-    const fresh = await cache.getEntry("tripA");
-    const freshClient = pool.created.get("tripA")![2]!;
-    const freshOps: Json0Op[] = [
-      {
-        p: ["title"],
-        od: fresh.snapshot.title,
-        oi: "recovered mutation",
-      },
-    ];
-    await submitOp(ctx, "tripA", freshOps);
-
+    const freshClient = pool.created.get("tripA")![1]!;
     expect(freshClient.submitCalled).toBe(1);
     expect((await cache.get("tripA")).title).toBe("recovered mutation");
   });

--- a/tests/unit/trip-cache.test.ts
+++ b/tests/unit/trip-cache.test.ts
@@ -1,83 +1,244 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it } from "vitest";
 import { TripCache } from "../../src/cache/trip-cache.ts";
+import type { AppContext } from "../../src/context.ts";
+import type { Json0Op } from "../../src/ot/apply.ts";
+import { submitOp } from "../../src/tools/shared.ts";
 import type { RestClient } from "../../src/transport/rest.ts";
-import type { ShareDBPool } from "../../src/transport/sharedb.ts";
+import type { ShareDBClient, ShareDBPool } from "../../src/transport/sharedb.ts";
 
 class FakeShareDBClient extends EventEmitter {
-  public version = 1;
+  public isSubscribed = false;
   public subscribeCalled = 0;
+  public submitCalled = 0;
+  public closeCalled = 0;
+  public closeDuringSubscribe = false;
+
+  constructor(
+    public version: number,
+    private readonly title: string,
+  ) {
+    super();
+  }
 
   async subscribe() {
     this.subscribeCalled++;
-    return { title: "Test Trip", sections: [] };
+    this.isSubscribed = true;
+    if (this.closeDuringSubscribe) this.isSubscribed = false;
+    return {
+      title: this.title,
+      itinerary: { sections: [] },
+    };
+  }
+
+  async submit(_ops: Json0Op[]): Promise<void> {
+    if (!this.isSubscribed) throw new Error("not subscribed");
+    this.submitCalled++;
+    this.version++;
+  }
+
+  disconnect(code = 1000): void {
+    this.isSubscribed = false;
+    this.emit("closed", code);
+  }
+
+  close(): void {
+    this.closeCalled++;
+    this.isSubscribed = false;
   }
 }
 
-describe("TripCache event listener leak", () => {
-  it("unregisters remoteOp listener on invalidate", async () => {
-    const fakeClient = new FakeShareDBClient();
-    const fakeRest = {
-      getTripWithResources: async () => ({ geos: [] }),
-    } as unknown as RestClient;
+class FakeShareDBPool {
+  public readonly created = new Map<string, FakeShareDBClient[]>();
+  private readonly clients = new Map<string, FakeShareDBClient>();
 
-    const fakePool = {
-      get: () => fakeClient,
-    } as unknown as ShareDBPool;
+  get(tripKey: string): FakeShareDBClient {
+    let client = this.clients.get(tripKey);
+    if (!client) {
+      const tripClients = this.created.get(tripKey) ?? [];
+      const sequence = tripClients.length + 1;
+      client = new FakeShareDBClient(sequence * 10, `${tripKey} snapshot ${sequence}`);
+      tripClients.push(client);
+      this.created.set(tripKey, tripClients);
+      this.clients.set(tripKey, client);
+    }
+    return client;
+  }
 
-    const cache = new TripCache(fakeRest, fakePool);
+  evict(tripKey: string, expectedClient?: ShareDBClient): boolean {
+    const client = this.clients.get(tripKey);
+    if (!client || (expectedClient && client !== expectedClient)) return false;
+    this.clients.delete(tripKey);
+    client.close();
+    return true;
+  }
 
-    // Initial get, should subscribe and register listener
+  has(tripKey: string): boolean {
+    return this.clients.has(tripKey);
+  }
+}
+
+function makeCache(): {
+  cache: TripCache;
+  pool: FakeShareDBPool;
+  getTripCalls: () => number;
+} {
+  let getTripCalls = 0;
+  const rest = {
+    getTripWithResources: async () => {
+      getTripCalls++;
+      return { geos: [] };
+    },
+  } as unknown as RestClient;
+  const pool = new FakeShareDBPool();
+  return {
+    cache: new TripCache(rest, pool as unknown as ShareDBPool),
+    pool,
+    getTripCalls: () => getTripCalls,
+  };
+}
+
+describe("TripCache subscription lifecycle", () => {
+  it("unregisters client listeners and evicts the client on invalidate", async () => {
+    const { cache, pool } = makeCache();
+
     await cache.get("tripA");
-    expect(fakeClient.listenerCount("remoteOp")).toBe(1);
+    const client = pool.created.get("tripA")![0]!;
+    expect(client.listenerCount("remoteOp")).toBe(1);
+    expect(client.listenerCount("closed")).toBe(1);
 
-    // Invalidate, should unregister listener
     cache.invalidate("tripA");
-    expect(fakeClient.listenerCount("remoteOp")).toBe(0);
+
+    expect(client.listenerCount("remoteOp")).toBe(0);
+    expect(client.listenerCount("closed")).toBe(0);
+    expect(client.closeCalled).toBe(1);
+    expect(pool.has("tripA")).toBe(false);
   });
 
-  it("handles multiple get/invalidate cycles without leaking listeners", async () => {
-    const fakeClient = new FakeShareDBClient();
-    const fakeRest = {
-      getTripWithResources: async () => ({ geos: [] }),
-    } as unknown as RestClient;
+  it("recovers from a normal close with a fresh client and snapshot", async () => {
+    const { cache, pool, getTripCalls } = makeCache();
+    const first = await cache.getEntry("tripA");
+    const firstClient = pool.created.get("tripA")![0]!;
 
-    const fakePool = {
-      get: () => fakeClient,
-    } as unknown as ShareDBPool;
+    firstClient.disconnect(1000);
 
-    const cache = new TripCache(fakeRest, fakePool);
+    expect(firstClient.listenerCount("remoteOp")).toBe(0);
+    expect(firstClient.listenerCount("closed")).toBe(0);
+    expect(pool.has("tripA")).toBe(false);
+
+    const second = await cache.getEntry("tripA");
+    const secondClient = pool.created.get("tripA")![1]!;
+    expect(second.snapshot.title).toBe("tripA snapshot 2");
+    expect(second.version).toBe(20);
+    expect(secondClient).not.toBe(firstClient);
+    expect(secondClient.subscribeCalled).toBe(1);
+    expect(getTripCalls()).toBe(2);
+  });
+
+  it("uses the same lazy recovery path after an abnormal close", async () => {
+    const { cache, pool } = makeCache();
+    await cache.get("tripA");
+    const firstClient = pool.created.get("tripA")![0]!;
+
+    firstClient.disconnect(1006);
+
+    expect(pool.has("tripA")).toBe(false);
+    expect(firstClient.closeCalled).toBe(1);
+    const trip = await cache.get("tripA");
+    expect(trip.title).toBe("tripA snapshot 2");
+  });
+
+  it("recovers the next mutation after a close races an earlier submit", async () => {
+    const { cache, pool } = makeCache();
+    const ctx = {
+      pool: pool as unknown as ShareDBPool,
+      tripCache: cache,
+    } as AppContext;
+    const first = await cache.getEntry("tripA");
+    const firstClient = pool.created.get("tripA")![0]!;
+    const staleOps: Json0Op[] = [
+      {
+        p: ["title"],
+        od: first.snapshot.title,
+        oi: "stale mutation",
+      },
+    ];
+
+    firstClient.disconnect(1000);
+
+    await expect(submitOp(ctx, "tripA", staleOps)).rejects.toMatchObject({
+      code: "not_subscribed",
+    });
+
+    const fresh = await cache.getEntry("tripA");
+    const freshClient = pool.created.get("tripA")![2]!;
+    const freshOps: Json0Op[] = [
+      {
+        p: ["title"],
+        od: fresh.snapshot.title,
+        oi: "recovered mutation",
+      },
+    ];
+    await submitOp(ctx, "tripA", freshOps);
+
+    expect(freshClient.submitCalled).toBe(1);
+    expect((await cache.get("tripA")).title).toBe("recovered mutation");
+  });
+
+  it("replaces an unsubscribed entry even when no close event was observed", async () => {
+    const { cache, pool } = makeCache();
+    await cache.get("tripA");
+    const firstClient = pool.created.get("tripA")![0]!;
+    firstClient.isSubscribed = false;
+
+    const trip = await cache.get("tripA");
+
+    expect(trip.title).toBe("tripA snapshot 2");
+    expect(firstClient.closeCalled).toBe(1);
+    expect(pool.created.get("tripA")).toHaveLength(2);
+  });
+
+  it("does not publish a snapshot if the subscription closes before caching", async () => {
+    const { cache, pool } = makeCache();
+    const client = pool.get("tripA");
+    client.closeDuringSubscribe = true;
+
+    await expect(cache.get("tripA")).rejects.toMatchObject({ code: "ws_closed" });
+    expect(client.listenerCount("remoteOp")).toBe(0);
+    expect(client.listenerCount("closed")).toBe(0);
+    expect(client.closeCalled).toBe(1);
+    expect(pool.has("tripA")).toBe(false);
+  });
+
+  it("handles repeated subscribe and invalidate cycles without leaking listeners", async () => {
+    const { cache, pool } = makeCache();
 
     for (let i = 0; i < 5; i++) {
       await cache.get("tripA");
-      expect(fakeClient.listenerCount("remoteOp")).toBe(1);
+      const client = pool.created.get("tripA")![i]!;
+      expect(client.listenerCount("remoteOp")).toBe(1);
+      expect(client.listenerCount("closed")).toBe(1);
       cache.invalidate("tripA");
-      expect(fakeClient.listenerCount("remoteOp")).toBe(0);
+      expect(client.listenerCount("remoteOp")).toBe(0);
+      expect(client.listenerCount("closed")).toBe(0);
     }
   });
 
-  it("unregisters listener on clear", async () => {
-    const fakeClient1 = new FakeShareDBClient();
-    const fakeClient2 = new FakeShareDBClient();
-    const fakeRest = {
-      getTripWithResources: async () => ({ geos: [] }),
-    } as unknown as RestClient;
-
-    const fakePool = {
-      get: (tripKey: string) => (tripKey === "tripA" ? fakeClient1 : fakeClient2),
-    } as unknown as ShareDBPool;
-
-    const cache = new TripCache(fakeRest, fakePool);
-
+  it("unregisters listeners and evicts every cached client on clear", async () => {
+    const { cache, pool } = makeCache();
     await cache.get("tripA");
     await cache.get("tripB");
-
-    expect(fakeClient1.listenerCount("remoteOp")).toBe(1);
-    expect(fakeClient2.listenerCount("remoteOp")).toBe(1);
+    const clientA = pool.created.get("tripA")![0]!;
+    const clientB = pool.created.get("tripB")![0]!;
 
     cache.clear();
 
-    expect(fakeClient1.listenerCount("remoteOp")).toBe(0);
-    expect(fakeClient2.listenerCount("remoteOp")).toBe(0);
+    for (const client of [clientA, clientB]) {
+      expect(client.listenerCount("remoteOp")).toBe(0);
+      expect(client.listenerCount("closed")).toBe(0);
+      expect(client.closeCalled).toBe(1);
+    }
+    expect(pool.has("tripA")).toBe(false);
+    expect(pool.has("tripB")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Tie cached trip snapshots to their exact ShareDB subscription so normal or abnormal socket closes evict the stale client and the next operation resubscribes from a fresh snapshot and version. Route `not_subscribed` through the existing invalidation path, while deliberately avoiding automatic replay of writes whose acknowledgements may have been lost.

Closes #59.

## Test plan

- `npm run build`
- `npm run test` — 430 unit tests
- `npm run lint -- --quiet`
- `git diff --check`
- Live integration suite using the macOS Keychain credential and an account-owned fixture trip — 49 tests across 10 files