### PR TITLE
Add a tool to reorder itinerary blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ and a ryokan in Shinjuku."
 | `wanderlog_edit_expense` | Change a budget expense's description, amount, currency, category, or date |
 | `wanderlog_annotate_place` | Update an existing place with a note, start/end time, or both |
 | `wanderlog_remove_place` | Remove a place by natural-language reference |
+| `wanderlog_move_block` | Move an existing place or reservation block within its current section |
 | `wanderlog_update_trip_dates` | Change a trip's date range |
 | `wanderlog_rename_day` | Rename a day's heading (e.g. `"Barcelona"` → `"Arrival — Feria de Abril"`) |
 | `wanderlog_list_journal` | List journal (travelogue) stops, optionally filtered by title or date |

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,11 @@ import {
   removePlaceInputSchema,
 } from "./tools/remove-place.js";
 import {
+  moveBlock,
+  moveBlockDescription,
+  moveBlockInputSchema,
+} from "./tools/move-block.js";
+import {
   searchPlaces,
   searchPlacesDescription,
   searchPlacesInputSchema,
@@ -465,6 +470,16 @@ export function buildServer(ctx: AppContext): McpServer {
       inputSchema: removePlaceInputSchema,
     },
     requireAuth(ctx, async (args) => removePlace(ctx, args as Parameters<typeof removePlace>[1])),
+  );
+
+  server.registerTool(
+    "wanderlog_move_block",
+    {
+      title: "Move a block within its itinerary section",
+      description: moveBlockDescription,
+      inputSchema: moveBlockInputSchema,
+    },
+    requireAuth(ctx, async (args) => moveBlock(ctx, args as Parameters<typeof moveBlock>[1])),
   );
 
   server.registerTool(

--- a/src/tools/move-block.ts
+++ b/src/tools/move-block.ts
@@ -36,14 +36,14 @@ export const moveBlockInputSchema = z
       .min(1)
       .optional()
       .describe(
-        "Move immediately before this naturally referenced place or reservation block in the same section.",
+        "Move immediately before this naturally referenced place or reservation block in the same section. Notes and checklists are not valid targets.",
       ),
     after: z
       .string()
       .min(1)
       .optional()
       .describe(
-        "Move immediately after this naturally referenced place or reservation block in the same section.",
+        "Move immediately after this naturally referenced place or reservation block in the same section. Notes and checklists are not valid targets.",
       ),
   })
   .refine(
@@ -67,9 +67,11 @@ day filters and ordinal prefixes. Choose exactly one destination:
   - before: another place or reservation block in the same section
   - after: another place or reservation block in the same section
 
-Positions count all displayed blocks, including notes and checklists. Cross-section moves are not
-supported. If a reference is ambiguous, nothing is changed and the tool returns candidates for a
-more specific retry.
+Positions count all displayed blocks, including notes and checklists — but notes and checklists
+cannot be used as before/after targets, which resolve only to place or reservation blocks.
+Cross-section moves are not supported; do not emulate them by removing and re-adding the block,
+which discards its ID, notes, times, and booking details. If a reference is ambiguous, nothing is
+changed and the tool returns candidates for a more specific retry.
 `.trim();
 
 type Args = z.infer<typeof moveBlockInputSchema>;

--- a/src/tools/move-block.ts
+++ b/src/tools/move-block.ts
@@ -1,0 +1,257 @@
+import { isDeepStrictEqual } from "node:util";
+import { z } from "zod";
+import type { AppContext } from "../context.js";
+import {
+  WanderlogError,
+  WanderlogValidationError,
+} from "../errors.js";
+import type { Json0Op } from "../ot/apply.js";
+import {
+  resolvePlaceRef,
+  type PlaceRefMatch,
+} from "../resolvers/place-ref.js";
+import type { Block, Section, TripPlan } from "../types.js";
+import { isPlaceBlock, isTransitBlock } from "../types.js";
+import { submitOp } from "./shared.js";
+
+export const moveBlockInputSchema = z
+  .object({
+    trip_key: z.string().min(1).describe("The trip containing the block."),
+    block: z
+      .string()
+      .min(1)
+      .describe(
+        "Natural-language reference to the place or reservation block to move. Uses the same names, role keywords, day filters, and ordinal prefixes as wanderlog_remove_place.",
+      ),
+    position: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe(
+        "Move to this 1-based position in the section's complete displayed block order, including notes and checklists.",
+      ),
+    before: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Move immediately before this naturally referenced place or reservation block in the same section.",
+      ),
+    after: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Move immediately after this naturally referenced place or reservation block in the same section.",
+      ),
+  })
+  .refine(
+    (args) =>
+      [args.position, args.before, args.after].filter(
+        (value) => value !== undefined,
+      ).length === 1,
+    {
+      message: "Provide exactly one of position, before, or after.",
+    },
+  );
+
+export const moveBlockDescription = `
+Moves an existing place or reservation block to another position within its current Wanderlog
+section without deleting or recreating it. The original block ID, notes, images, times, booking
+details, and other metadata are preserved.
+
+Select the block using the same natural-language references as wanderlog_remove_place, including
+day filters and ordinal prefixes. Choose exactly one destination:
+  - position: a 1-based position in the section's complete displayed block order
+  - before: another place or reservation block in the same section
+  - after: another place or reservation block in the same section
+
+Positions count all displayed blocks, including notes and checklists. Cross-section moves are not
+supported. If a reference is ambiguous, nothing is changed and the tool returns candidates for a
+more specific retry.
+`.trim();
+
+type Args = z.infer<typeof moveBlockInputSchema>;
+
+type MoveOutcome = {
+  moved: boolean;
+  blockName: string;
+  sectionLabel: string;
+  tripTitle: string;
+  fromPosition: number;
+  toPosition: number;
+};
+
+export async function moveBlock(
+  ctx: AppContext,
+  args: Args,
+): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+  try {
+    // The MCP SDK unwraps refined Zod objects before protocol validation.
+    const parsed = moveBlockInputSchema.safeParse(args);
+    if (!parsed.success) {
+      throw new WanderlogValidationError(
+        parsed.error.issues[0]?.message ?? "Invalid move destination.",
+      );
+    }
+
+    const outcome = await submitOp(ctx, parsed.data.trip_key, (trip) =>
+      buildMove(trip, parsed.data),
+    );
+
+    const text = outcome.moved
+      ? `Moved ${outcome.blockName} from position ${outcome.fromPosition} to position ${outcome.toPosition} in ${outcome.sectionLabel} of "${outcome.tripTitle}".`
+      : `${outcome.blockName} is already at position ${outcome.toPosition} in ${outcome.sectionLabel} of "${outcome.tripTitle}". No changes made.`;
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const msg =
+      err instanceof WanderlogError
+        ? err.toUserMessage()
+        : `Unexpected error: ${(err as Error).message}`;
+    return { content: [{ type: "text", text: msg }], isError: true };
+  }
+}
+
+function buildMove(
+  trip: TripPlan,
+  args: Args,
+): {
+  ops: Json0Op[];
+  afterApply: (snapshot: TripPlan) => MoveOutcome;
+} {
+  const source = resolveUniqueBlock(trip, args.block, "block");
+  const sourceIndex = source.blockIndex;
+  let destinationIndex: number;
+
+  if (args.position !== undefined) {
+    if (args.position > source.section.blocks.length) {
+      throw new WanderlogValidationError(
+        `Position ${args.position} is outside ${formatSection(source.section)}, which has ${source.section.blocks.length} blocks.`,
+        `Use a position from 1 to ${source.section.blocks.length}, or use before/after with another block in the section.`,
+      );
+    }
+    destinationIndex = args.position - 1;
+  } else {
+    const relation = args.before !== undefined ? "before" : "after";
+    const targetRef = args.before ?? args.after!;
+    const target = resolveUniqueBlock(trip, targetRef, `${relation} target`);
+
+    if (target.sectionIndex !== source.sectionIndex) {
+      throw new WanderlogValidationError(
+        `Cannot move ${blockName(source.block)} ${relation} ${blockName(target.block)} because they are in different sections.`,
+        "Cross-section moves are not supported. Choose a target in the same day or section.",
+      );
+    }
+    if (target.block.id === source.block.id) {
+      throw new WanderlogValidationError(
+        `Cannot move ${blockName(source.block)} ${relation} itself.`,
+      );
+    }
+
+    const targetIndex = target.blockIndex;
+    if (relation === "before") {
+      destinationIndex =
+        targetIndex < sourceIndex ? targetIndex : targetIndex - 1;
+    } else {
+      destinationIndex =
+        targetIndex < sourceIndex ? targetIndex + 1 : targetIndex;
+    }
+  }
+
+  const originalBlock = structuredClone(source.block);
+  const outcome: MoveOutcome = {
+    moved: destinationIndex !== sourceIndex,
+    blockName: blockName(source.block),
+    sectionLabel: formatSection(source.section),
+    tripTitle: trip.title,
+    fromPosition: sourceIndex + 1,
+    toPosition: destinationIndex + 1,
+  };
+  const ops: Json0Op[] =
+    destinationIndex === sourceIndex
+      ? []
+      : [
+          {
+            p: [
+              "itinerary",
+              "sections",
+              source.sectionIndex,
+              "blocks",
+              sourceIndex,
+            ],
+            lm: destinationIndex,
+          },
+        ];
+
+  return {
+    ops,
+    afterApply: (snapshot) => {
+      const section = snapshot.itinerary.sections.find(
+        (candidate) => candidate.id === source.section.id,
+      );
+      const movedBlock = section?.blocks[destinationIndex];
+      if (
+        !movedBlock ||
+        movedBlock.id !== originalBlock.id ||
+        !isDeepStrictEqual(movedBlock, originalBlock)
+      ) {
+        throw new WanderlogError(
+          `The move was accepted but could not be verified. It may have been applied; refresh "${trip.title}" before retrying.`,
+          "move_verification_failed",
+          "Use wanderlog_get_trip to inspect the current itinerary order before making another move.",
+        );
+      }
+      return outcome;
+    },
+  };
+}
+
+function resolveUniqueBlock(
+  trip: TripPlan,
+  ref: string,
+  label: string,
+): PlaceRefMatch {
+  const result = resolvePlaceRef(trip, ref);
+  if (result.kind === "none") {
+    throw new WanderlogValidationError(
+      `No itinerary block matching "${ref}" was found in "${trip.title}".`,
+      "Use wanderlog_get_trip to inspect the current itinerary, then retry with a more specific name or role.",
+    );
+  }
+  if (result.kind === "ambiguous") {
+    const candidates = result.candidates
+      .map(
+        (candidate, index) =>
+          `  ${index + 1}. ${blockName(candidate.block)} — ${formatSection(candidate.section)}`,
+      )
+      .join("\n");
+    throw new WanderlogValidationError(
+      `The ${label} reference "${ref}" is ambiguous:\n${candidates}`,
+      `Retry with an ordinal prefix such as "1st ${ref}" or add a day filter.`,
+    );
+  }
+  return result.match;
+}
+
+function blockName(block: Block): string {
+  if (isPlaceBlock(block)) return block.place.name;
+  if (block.type === "flight") {
+    const flightInfo = "flightInfo" in block ? block.flightInfo : undefined;
+    const airline = flightInfo?.airline?.iata;
+    const number = flightInfo?.number;
+    return airline || number ? `${airline ?? ""}${number ?? ""} flight` : "flight";
+  }
+  if (isTransitBlock(block)) {
+    return block.carrier ? `${block.carrier} ${block.type}` : block.type;
+  }
+  if (block.type === "rentalCar") return "rental car";
+  return `${block.type} block`;
+}
+
+function formatSection(section: Section): string {
+  if (section.mode === "dayPlan" && section.date) {
+    return `day ${section.date}`;
+  }
+  return `"${section.heading || section.type}"`;
+}

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -51,12 +51,45 @@ async function withSubmitLock<T>(
  *   next read refetches a fresh snapshot from the server.
  * - On success, cache.applyLocalOp() is called with the server-accepted version.
  */
-export async function submitOp(
+export type LockScopedOp<T> = {
+  ops: Json0Op[];
+  afterApply: (snapshot: TripPlan) => T;
+};
+
+export type LockScopedOpBuilder<T> = (snapshot: TripPlan) => LockScopedOp<T>;
+
+export function submitOp(
   ctx: AppContext,
   tripKey: string,
   ops: Json0Op[],
-): Promise<void> {
+): Promise<void>;
+export function submitOp<T>(
+  ctx: AppContext,
+  tripKey: string,
+  build: LockScopedOpBuilder<T>,
+): Promise<T>;
+export async function submitOp<T>(
+  ctx: AppContext,
+  tripKey: string,
+  opsOrBuilder: Json0Op[] | LockScopedOpBuilder<T>,
+): Promise<T | void> {
   return withSubmitLock(tripKey, async () => {
+    let snapshot: TripPlan | undefined;
+    let afterApply: ((snapshot: TripPlan) => T) | undefined;
+    let ops: Json0Op[];
+
+    if (typeof opsOrBuilder === "function") {
+      snapshot = await ctx.tripCache.get(tripKey);
+      const prepared = opsOrBuilder(snapshot);
+      ops = prepared.ops;
+      afterApply = prepared.afterApply;
+      if (ops.length === 0) {
+        return afterApply(snapshot);
+      }
+    } else {
+      ops = opsOrBuilder;
+    }
+
     const client = ctx.pool.get(tripKey);
     if (!client.isSubscribed) {
       throw new WanderlogError(
@@ -67,6 +100,10 @@ export async function submitOp(
     try {
       await submitWithRateLimitRetry(client, ops);
       ctx.tripCache.applyLocalOp(tripKey, ops, client.version);
+      if (afterApply) {
+        const updated = await ctx.tripCache.get(tripKey);
+        return afterApply(updated);
+      }
     } catch (err) {
       // Any submit failure leaves our cached view possibly inconsistent with
       // the server. Invalidate so the next get() refetches + resubscribes.

--- a/tests/integration/mcp-smoke.test.ts
+++ b/tests/integration/mcp-smoke.test.ts
@@ -87,7 +87,7 @@ describe("MCP stdio server (smoke)", () => {
     expect(p.pid).toBeDefined();
   });
 
-  it("responds to tools/list with all 32 tools", async () => {
+  it("responds to tools/list with all 33 tools", async () => {
     const p = startServer();
     await waitForReady(p);
     await initialize(p);
@@ -122,6 +122,7 @@ describe("MCP stdio server (smoke)", () => {
       "wanderlog_list_expenses",
       "wanderlog_list_journal",
       "wanderlog_list_trips",
+      "wanderlog_move_block",
       "wanderlog_remove_expense",
       "wanderlog_remove_journal",
       "wanderlog_remove_note",

--- a/tests/integration/mutations.test.ts
+++ b/tests/integration/mutations.test.ts
@@ -6,6 +6,7 @@ import { addNote } from "../../src/tools/add-note.ts";
 import { addPlace } from "../../src/tools/add-place.ts";
 import { createTrip } from "../../src/tools/create-trip.ts";
 import { getTrip } from "../../src/tools/get-trip.ts";
+import { moveBlock } from "../../src/tools/move-block.ts";
 import { removePlace } from "../../src/tools/remove-place.ts";
 import { updateTripDates } from "../../src/tools/update-trip-dates.ts";
 import { isChecklistBlock, isPlaceBlock } from "../../src/types.ts";
@@ -95,6 +96,75 @@ describe("Mutation tools (live round-trip)", () => {
     );
     expect(foundInDay1).toBe(true);
   }, 30_000);
+
+  it("move_block reorders day places in both directions without changing their blocks", async () => {
+    expect(tripKey).toBeDefined();
+    for (const place of ["Praça do Comércio", "Elevador de Santa Justa"]) {
+      const addResult = await addPlace(ctx, {
+        trip_key: tripKey!,
+        place,
+        day: "day 1",
+        start_time: place === "Praça do Comércio" ? "11:00" : "13:00",
+        end_time: place === "Praça do Comércio" ? "12:00" : "14:00",
+        note: `Integration metadata for ${place}`,
+      });
+      if (addResult.isError) {
+        throw new Error(`add_place failed: ${addResult.content[0]!.text}`);
+      }
+    }
+
+    const before = await ctx.rest.getTrip(tripKey!);
+    const beforeDay = before.itinerary.sections.find(
+      (section) => section.mode === "dayPlan" && section.date === "2099-01-01",
+    )!;
+    const originalBlocks = beforeDay.blocks.map((block) => structuredClone(block));
+    const originalIds = originalBlocks.map((block) => block.id);
+    expect(originalIds).toHaveLength(3);
+
+    const backward = await moveBlock(ctx, {
+      trip_key: tripKey!,
+      block: "Elevador de Santa Justa",
+      before: "Castelo de São Jorge",
+    });
+    if (backward.isError) {
+      throw new Error(`move_block backward failed: ${backward.content[0]!.text}`);
+    }
+
+    const afterBackward = await ctx.rest.getTrip(tripKey!);
+    const backwardBlocks = afterBackward.itinerary.sections.find(
+      (section) => section.mode === "dayPlan" && section.date === "2099-01-01",
+    )!.blocks;
+    expect(backwardBlocks.map((block) => block.id)).toEqual([
+      originalIds[2],
+      originalIds[0],
+      originalIds[1],
+    ]);
+    for (const original of originalBlocks) {
+      expect(backwardBlocks.find((block) => block.id === original.id)).toEqual(
+        original,
+      );
+    }
+
+    const forward = await moveBlock(ctx, {
+      trip_key: tripKey!,
+      block: "Elevador de Santa Justa",
+      after: "Praça do Comércio",
+    });
+    if (forward.isError) {
+      throw new Error(`move_block forward failed: ${forward.content[0]!.text}`);
+    }
+
+    const afterForward = await ctx.rest.getTrip(tripKey!);
+    const forwardBlocks = afterForward.itinerary.sections.find(
+      (section) => section.mode === "dayPlan" && section.date === "2099-01-01",
+    )!.blocks;
+    expect(forwardBlocks.map((block) => block.id)).toEqual(originalIds);
+    for (const original of originalBlocks) {
+      expect(forwardBlocks.find((block) => block.id === original.id)).toEqual(
+        original,
+      );
+    }
+  }, 90_000);
 
   it("add_hotel adds a hotel with a check-in window", async () => {
     expect(tripKey).toBeDefined();

--- a/tests/integration/mutations.test.ts
+++ b/tests/integration/mutations.test.ts
@@ -120,11 +120,21 @@ describe("Mutation tools (live round-trip)", () => {
     const originalBlocks = beforeDay.blocks.map((block) => structuredClone(block));
     const originalIds = originalBlocks.map((block) => block.id);
     expect(originalIds).toHaveLength(3);
+    expect(originalBlocks.every(isPlaceBlock)).toBe(true);
+    const firstName = isPlaceBlock(originalBlocks[0]!)
+      ? originalBlocks[0]!.place.name
+      : "";
+    const secondName = isPlaceBlock(originalBlocks[1]!)
+      ? originalBlocks[1]!.place.name
+      : "";
+    const thirdName = isPlaceBlock(originalBlocks[2]!)
+      ? originalBlocks[2]!.place.name
+      : "";
 
     const backward = await moveBlock(ctx, {
       trip_key: tripKey!,
-      block: "Elevador de Santa Justa",
-      before: "Castelo de São Jorge",
+      block: thirdName,
+      before: firstName,
     });
     if (backward.isError) {
       throw new Error(`move_block backward failed: ${backward.content[0]!.text}`);
@@ -147,8 +157,8 @@ describe("Mutation tools (live round-trip)", () => {
 
     const forward = await moveBlock(ctx, {
       trip_key: tripKey!,
-      block: "Elevador de Santa Justa",
-      after: "Praça do Comércio",
+      block: thirdName,
+      after: secondName,
     });
     if (forward.isError) {
       throw new Error(`move_block forward failed: ${forward.content[0]!.text}`);

--- a/tests/unit/move-block.test.ts
+++ b/tests/unit/move-block.test.ts
@@ -1,0 +1,412 @@
+import { describe, expect, it } from "vitest";
+import type { AppContext } from "../../src/context.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
+import {
+  moveBlock,
+  moveBlockInputSchema,
+} from "../../src/tools/move-block.ts";
+import type { Block, TripPlan } from "../../src/types.ts";
+
+function place(id: number, name: string): Block {
+  return {
+    id,
+    type: "place",
+    place: {
+      name,
+      place_id: `ChIJ_${id}`,
+      photo_urls: [`https://example.com/${id}.jpg`],
+    },
+    text: { ops: [{ insert: `Notes for ${name}\n` }] },
+    startTime: "09:00",
+    endTime: "10:00",
+    imageKeys: [`image-${id}`],
+  };
+}
+
+function fixture(): TripPlan {
+  return {
+    id: 1,
+    key: "trip",
+    title: "Move test",
+    userId: 1,
+    privacy: "private",
+    startDate: "2026-08-01",
+    endDate: "2026-08-01",
+    days: 1,
+    placeCount: 4,
+    schemaVersion: 2,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    contributors: [],
+    itinerary: {
+      sections: [
+        {
+          id: 10,
+          type: "hotels",
+          mode: "placeList",
+          heading: "Hotels and lodging",
+          date: null,
+          blocks: [
+            {
+              ...place(50, "Test Hotel"),
+              hotel: {
+                checkIn: "2026-08-01",
+                checkOut: "2026-08-02",
+                travelerNames: ["Traveler"],
+                confirmationNumber: "HOTEL-123",
+              },
+            },
+          ],
+        },
+        {
+          id: 20,
+          type: "normal",
+          mode: "dayPlan",
+          heading: "Day in town",
+          date: "2026-08-01",
+          blocks: [
+            place(101, "Alpha Museum"),
+            {
+              id: 102,
+              type: "note",
+              text: { ops: [{ insert: "Walk five minutes.\n" }] },
+            },
+            place(103, "Bravo Cafe"),
+            place(104, "Charlie Park"),
+          ],
+        },
+      ],
+    },
+  };
+}
+
+function makeFakeContext(
+  trip: TripPlan,
+  options: { applyLocally?: boolean } = {},
+): {
+  ctx: AppContext;
+  submittedOps: Json0Op[][];
+  currentTrip: () => TripPlan;
+  invalidations: () => number;
+} {
+  let snapshot = structuredClone(trip);
+  let invalidationCount = 0;
+  const submittedOps: Json0Op[][] = [];
+  const client = {
+    isSubscribed: true,
+    version: 1,
+    async submit(ops: Json0Op[]) {
+      submittedOps.push(ops);
+      this.version += 1;
+    },
+  };
+  const ctx = {
+    pool: { get: () => client },
+    tripCache: {
+      get: async () => snapshot,
+      applyLocalOp: (_tripKey: string, ops: Json0Op[]) => {
+        if (options.applyLocally !== false) {
+          snapshot = applyOp(snapshot, ops);
+        }
+      },
+      invalidate: () => {
+        invalidationCount += 1;
+      },
+    },
+  } as unknown as AppContext;
+  return {
+    ctx,
+    submittedOps,
+    currentTrip: () => snapshot,
+    invalidations: () => invalidationCount,
+  };
+}
+
+function dayIds(trip: TripPlan): number[] {
+  return trip.itinerary.sections[1]!.blocks.map((block) => block.id);
+}
+
+describe("moveBlockInputSchema", () => {
+  const base = { trip_key: "trip", block: "Alpha Museum" };
+
+  it("accepts each destination form", () => {
+    expect(
+      moveBlockInputSchema.safeParse({ ...base, position: 2 }).success,
+    ).toBe(true);
+    expect(
+      moveBlockInputSchema.safeParse({ ...base, before: "Bravo Cafe" }).success,
+    ).toBe(true);
+    expect(
+      moveBlockInputSchema.safeParse({ ...base, after: "Bravo Cafe" }).success,
+    ).toBe(true);
+  });
+
+  it("requires exactly one valid destination", () => {
+    expect(moveBlockInputSchema.safeParse(base).success).toBe(false);
+    expect(
+      moveBlockInputSchema.safeParse({
+        ...base,
+        position: 2,
+        before: "Bravo Cafe",
+      }).success,
+    ).toBe(false);
+    expect(
+      moveBlockInputSchema.safeParse({ ...base, position: 0 }).success,
+    ).toBe(false);
+    expect(
+      moveBlockInputSchema.safeParse({ ...base, position: 1.5 }).success,
+    ).toBe(false);
+  });
+});
+
+describe("moveBlock absolute positions", () => {
+  it("counts notes in the complete displayed block order", async () => {
+    const fake = makeFakeContext(fixture());
+    const original = structuredClone(
+      fake.currentTrip().itinerary.sections[1]!.blocks[2],
+    );
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Bravo Cafe",
+      position: 1,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(fake.submittedOps).toEqual([
+      [
+        {
+          p: ["itinerary", "sections", 1, "blocks", 2],
+          lm: 0,
+        },
+      ],
+    ]);
+    expect(dayIds(fake.currentTrip())).toEqual([103, 101, 102, 104]);
+    expect(fake.currentTrip().itinerary.sections[1]!.blocks[0]).toEqual(
+      original,
+    );
+  });
+
+  it("moves a block forward to the final position", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      position: 4,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(fake.submittedOps[0]![0]).toMatchObject({
+      p: ["itinerary", "sections", 1, "blocks", 0],
+      lm: 3,
+    });
+    expect(dayIds(fake.currentTrip())).toEqual([102, 103, 104, 101]);
+  });
+
+  it("returns a non-mutating success when already at the requested position", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Bravo Cafe",
+      position: 3,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toContain("No changes made");
+    expect(fake.submittedOps).toHaveLength(0);
+    expect(dayIds(fake.currentTrip())).toEqual([101, 102, 103, 104]);
+  });
+
+  it("rejects a position beyond the section length", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      position: 5,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("has 4 blocks");
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+});
+
+describe("moveBlock relative index calculations", () => {
+  const cases = [
+    {
+      name: "moves before a target after the source",
+      block: "Alpha Museum",
+      destination: { before: "Charlie Park" },
+      op: { source: 0, destination: 2 },
+      ids: [102, 103, 101, 104],
+    },
+    {
+      name: "moves after a target after the source",
+      block: "Alpha Museum",
+      destination: { after: "Charlie Park" },
+      op: { source: 0, destination: 3 },
+      ids: [102, 103, 104, 101],
+    },
+    {
+      name: "moves before a target before the source",
+      block: "Charlie Park",
+      destination: { before: "Alpha Museum" },
+      op: { source: 3, destination: 0 },
+      ids: [104, 101, 102, 103],
+    },
+    {
+      name: "moves after a target before the source",
+      block: "Charlie Park",
+      destination: { after: "Alpha Museum" },
+      op: { source: 3, destination: 1 },
+      ids: [101, 104, 102, 103],
+    },
+  ] as const;
+
+  for (const testCase of cases) {
+    it(testCase.name, async () => {
+      const fake = makeFakeContext(fixture());
+
+      const result = await moveBlock(fake.ctx, {
+        trip_key: "trip",
+        block: testCase.block,
+        ...testCase.destination,
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(fake.submittedOps[0]![0]).toMatchObject({
+        p: [
+          "itinerary",
+          "sections",
+          1,
+          "blocks",
+          testCase.op.source,
+        ],
+        lm: testCase.op.destination,
+      });
+      expect(dayIds(fake.currentTrip())).toEqual(testCase.ids);
+    });
+  }
+
+  it("skips an already-satisfied before move", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Bravo Cafe",
+      before: "Charlie Park",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+
+  it("skips an already-satisfied after move", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Charlie Park",
+      after: "Bravo Cafe",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+});
+
+describe("moveBlock reference and safety errors", () => {
+  it("rejects missing source references without submitting", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Missing Museum",
+      position: 1,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("No itinerary block matching");
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+
+  it("returns candidates for an ambiguous source", async () => {
+    const trip = fixture();
+    trip.itinerary.sections[1]!.blocks.push(place(105, "Alpha Museum"));
+    const fake = makeFakeContext(trip);
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      position: 1,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("is ambiguous");
+    expect(result.content[0]!.text).toContain("1st Alpha Museum");
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+
+  it("returns candidates for an ambiguous relative target", async () => {
+    const trip = fixture();
+    trip.itinerary.sections[1]!.blocks.push(place(105, "Bravo Cafe"));
+    const fake = makeFakeContext(trip);
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      before: "Bravo Cafe",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("before target");
+    expect(result.content[0]!.text).toContain("is ambiguous");
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+
+  it("rejects a role-keyword target in another section", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      before: "the hotel",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("different sections");
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+
+  it("rejects moving a block relative to itself", async () => {
+    const fake = makeFakeContext(fixture());
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      before: "Alpha Museum",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("before itself");
+    expect(fake.submittedOps).toHaveLength(0);
+  });
+
+  it("invalidates the cache when post-apply verification fails", async () => {
+    const fake = makeFakeContext(fixture(), { applyLocally: false });
+
+    const result = await moveBlock(fake.ctx, {
+      trip_key: "trip",
+      block: "Alpha Museum",
+      position: 4,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("may have been applied");
+    expect(fake.submittedOps).toHaveLength(1);
+    expect(fake.invalidations()).toBe(1);
+  });
+});

--- a/tests/unit/submit-lock.test.ts
+++ b/tests/unit/submit-lock.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { AppContext } from "../../src/context.ts";
-import type { Json0Op } from "../../src/ot/apply.ts";
+import { applyOp, type Json0Op } from "../../src/ot/apply.ts";
 import { submitOp } from "../../src/tools/shared.ts";
+import type { TripPlan } from "../../src/types.ts";
 
 /**
  * Exercises the per-trip submit mutex in isolation. Uses a fake AppContext
@@ -157,5 +158,86 @@ describe("submitOp per-trip mutex", () => {
     await submitOp(holder.ctx, "tripA", ops);
     expect(holder.applyLocalOpCount).toBe(1);
     expect(holder.invalidateCount).toBe(0);
+  });
+
+  it("builds index-sensitive ops from the latest snapshot while holding the lock", async () => {
+    let snapshot = {
+      itinerary: {
+        sections: [
+          {
+            id: 1,
+            type: "normal",
+            mode: "dayPlan",
+            heading: "",
+            date: "2026-08-01",
+            blocks: [
+              { id: 1, type: "place", place: { name: "A", place_id: "A" } },
+              { id: 2, type: "place", place: { name: "B", place_id: "B" } },
+            ],
+          },
+        ],
+      },
+    } as TripPlan;
+    const submittedOps: Json0Op[][] = [];
+    const events: string[] = [];
+    const client = {
+      isSubscribed: true,
+      version: 1,
+      async submit(ops: Json0Op[]) {
+        submittedOps.push(ops);
+        this.version += 1;
+      },
+    };
+    const ctx = {
+      pool: { get: () => client },
+      tripCache: {
+        get: async () => snapshot,
+        applyLocalOp: (_tripKey: string, ops: Json0Op[]) => {
+          snapshot = applyOp(snapshot, ops);
+        },
+        invalidate: () => {},
+      },
+    } as unknown as AppContext;
+
+    await Promise.all([
+      submitOp(ctx, "tripA", [
+        { p: ["itinerary", "sections", 0, "blocks", 0], lm: 1 },
+      ]),
+      submitOp(ctx, "tripA", (lockedSnapshot) => {
+        events.push(
+          `second-build:${lockedSnapshot.itinerary.sections[0]!.blocks.map((b) => b.id).join(",")}`,
+        );
+        return {
+          ops: [
+            {
+              p: ["itinerary", "sections", 0, "blocks", 1],
+              lm: 0,
+            },
+          ],
+          afterApply: (updated) => {
+            events.push(
+              `second-after:${updated.itinerary.sections[0]!.blocks.map((b) => b.id).join(",")}`,
+            );
+            return undefined;
+          },
+        };
+      }),
+      submitOp(ctx, "tripA", (lockedSnapshot) => {
+        events.push(
+          `third-build:${lockedSnapshot.itinerary.sections[0]!.blocks.map((b) => b.id).join(",")}`,
+        );
+        return {
+          ops: [],
+          afterApply: () => undefined,
+        };
+      }),
+    ]);
+
+    expect(submittedOps).toHaveLength(2);
+    expect(events).toEqual([
+      "second-build:2,1",
+      "second-after:1,2",
+      "third-build:1,2",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Add `wanderlog_move_block` for moving an existing place or reservation block within its current section by 1-based position or relative `before`/`after` reference. The move uses a single JSON0 `lm` operation, resolves indices inside the per-trip submit lock, and verifies that the original block and metadata are preserved after applying it.

Closes #61.

## Test plan

- `npm run lint`
- `npm run build`
- `npm run test` — 440 tests passed
- Sequential `tests/integration` run with Keychain-injected credentials — 50 tests passed
- Covered absolute positions, all four before/after direction combinations, mixed block arrays, no-ops, ambiguity, self-targeting, cross-section rejection, metadata preservation, lock freshness, and live forward/backward moves

## Agent-facing surface changes

- [x] Changed a tool description, parameter doc, or error message
      (these are prompts shipped to other agents — review for
      injection risk and clarity)
- [ ] Changed or relaxed an invariant in `docs/architecture.md`